### PR TITLE
Add new method to get raw JSONPath results

### DIFF
--- a/confectory-core/src/main/java/net/obvj/confectory/Configuration.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/Configuration.java
@@ -159,6 +159,12 @@ public final class Configuration<T> implements ConfigurationDataRetriever<T>, Co
     }
 
     @Override
+    public Object get(String key)
+    {
+        return getService().get(key);
+    }
+
+    @Override
     public Boolean getBoolean(String key)
     {
         return getService().getBoolean(key);
@@ -305,6 +311,12 @@ final class ConfigurationService<T> implements ConfigurationDataRetriever<T>
     public T getBean()
     {
         return bean;
+    }
+
+    @Override
+    public Object get(String key)
+    {
+        return helper.get(key);
     }
 
     @Override

--- a/confectory-core/src/main/java/net/obvj/confectory/ConfigurationDataRetriever.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/ConfigurationDataRetriever.java
@@ -37,6 +37,22 @@ public interface ConfigurationDataRetriever<T>
     T getBean();
 
     /**
+     * Returns the object associated with the specified {@code key}.
+     * <p>
+     * <b>Note:</b> The actual return type may vary depending on the underlying
+     * implementation.
+     *
+     * @param key the object key (some implementations may also accept a path expression, e.g:
+     *            {@code JSONPath})
+     *
+     * @return the object object associated with the specified {@code key}; {@code null} if
+     *         not found
+     *
+     * @since 1.2.0
+     */
+    Object get(String key);
+
+    /**
      * Returns the {@code Boolean} object associated with the specified {@code key}.
      *
      * @param key the object key (some implementations may also accept a path expression, e.g:

--- a/confectory-core/src/main/java/net/obvj/confectory/ConfigurationDataRetriever.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/ConfigurationDataRetriever.java
@@ -39,14 +39,18 @@ public interface ConfigurationDataRetriever<T>
     /**
      * Returns the object associated with the specified {@code key}.
      * <p>
-     * <b>Note:</b> The actual return type may vary depending on the underlying
-     * implementation.
+     * <b>Notes:</b>
+     * <ul>
+     * <li>The actual return type may vary depending on the underlying implementation</li>
+     * <li>On a JSON implementation, the return will usually be an array</li>
+     * </ul>
      *
      * @param key the object key (some implementations may also accept a path expression, e.g:
      *            {@code JSONPath})
      *
-     * @return the object object associated with the specified {@code key}; {@code null} if
-     *         not found
+     * @return the object object associated with the specified {@code key}. Depending on the
+     *         actual implementation, the result may be either {@code null} or an empty array
+     *         if the specified key is not found
      *
      * @since 1.2.0
      */

--- a/confectory-core/src/main/java/net/obvj/confectory/helper/BeanConfigurationHelper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/helper/BeanConfigurationHelper.java
@@ -41,7 +41,18 @@ public class BeanConfigurationHelper<T> extends BasicConfigurationHelper<T>
     /**
      * @param key not used since this method implementation is a "no-op"
      * @throws ConfigurationException always, since the data for this type of helper should be
-     *                                handled by the user-defined bean
+     *                                retrieved by the user-defined bean
+     */
+    @Override
+    public Object get(String key)
+    {
+        throw newConfigurationException();
+    }
+
+    /**
+     * @param key not used since this method implementation is a "no-op"
+     * @throws ConfigurationException always, since the data for this type of helper should be
+     *                                retrieved by the user-defined bean
      */
     @Override
     public String getString(String key)
@@ -52,7 +63,7 @@ public class BeanConfigurationHelper<T> extends BasicConfigurationHelper<T>
     /**
      * @param key not used since this method implementation is a "no-op"
      * @throws ConfigurationException always, since the data for this type of helper should be
-     *                                handled by the user-defined bean
+     *                                retrieved by the user-defined bean
      */
     @Override
     public String getMandatoryString(String key)

--- a/confectory-core/src/main/java/net/obvj/confectory/helper/GenericJsonConfigurationHelper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/helper/GenericJsonConfigurationHelper.java
@@ -253,7 +253,7 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
      *
      * @param jsonPath the path to read
      * @return the {@code String} object associated with the specified {@code jsonPath};
-     *         {@code null} if the path is found
+     *         {@code null} if the path is not found
      *
      * @throws IllegalArgumentException if {@code jsonPath} is null or empty
      * @throws InvalidPathException     if the {@code jsonPath} expression is not valid

--- a/confectory-core/src/main/java/net/obvj/confectory/helper/GenericJsonConfigurationHelper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/helper/GenericJsonConfigurationHelper.java
@@ -76,11 +76,12 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
      * @return the {@code Boolean} object associated with the specified {@code jsonPath};
      *         {@code null} if not found
      *
-     * @throws InvalidPathException   if the {@code jsonPath} expression is not valid
-     * @throws ConfigurationException if the {@code jsonPath} expression returns more than a
-     *                                single element
-     * @throws ClassCastException     if the {@code jsonPath} result cannot be assigned to
-     *                                {@code boolean}
+     * @throws IllegalArgumentException if {@code jsonPath} is null or empty
+     * @throws InvalidPathException     if the {@code jsonPath} expression is not valid
+     * @throws ConfigurationException   if the {@code jsonPath} expression returns more than a
+     *                                  single element
+     * @throws ClassCastException       if the {@code jsonPath} result cannot be assigned to
+     *                                  {@code boolean}
      */
     @Override
     public Boolean getBoolean(String jsonPath)
@@ -97,11 +98,12 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
      * @return the {@code Boolean} object associated with the specified {@code jsonPath};
      *         never {@code null}
      *
-     * @throws InvalidPathException   if the {@code jsonPath} expression is not valid
-     * @throws ConfigurationException if not value found or the {@code jsonPath} expression
-     *                                returns more than a single element
-     * @throws ClassCastException     if the {@code jsonPath} result cannot be assigned to
-     *                                {@code boolean}
+     * @throws IllegalArgumentException if {@code jsonPath} is null or empty
+     * @throws InvalidPathException     if the {@code jsonPath} expression is not valid
+     * @throws ConfigurationException   if not value found or the {@code jsonPath} expression
+     *                                  returns more than a single element
+     * @throws ClassCastException       if the {@code jsonPath} result cannot be assigned to
+     *                                  {@code boolean}
      * @since 0.4.0
      */
     @Override
@@ -119,11 +121,12 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
      * @return the {@code Integer} object associated with the specified {@code jsonPath};
      *         {@code null} if not found
      *
-     * @throws InvalidPathException   if the {@code jsonPath} expression is not valid
-     * @throws ConfigurationException if the {@code jsonPath} expression returns more than a
-     *                                single element
-     * @throws ClassCastException     if the {@code jsonPath} result cannot be assigned to
-     *                                {@code int}
+     * @throws IllegalArgumentException if {@code jsonPath} is null or empty
+     * @throws InvalidPathException     if the {@code jsonPath} expression is not valid
+     * @throws ConfigurationException   if the {@code jsonPath} expression returns more than a
+     *                                  single element
+     * @throws ClassCastException       if the {@code jsonPath} result cannot be assigned to
+     *                                  {@code int}
      */
     @Override
     public Integer getInteger(String jsonPath)
@@ -140,11 +143,12 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
      * @return the {@code Integer} object associated with the specified {@code jsonPath};
      *         never {@code null}
      *
-     * @throws InvalidPathException   if the {@code jsonPath} expression is not valid
-     * @throws ConfigurationException if not value found or the {@code jsonPath} expression
-     *                                returns more than a single element
-     * @throws ClassCastException     if the {@code jsonPath} result cannot be assigned to
-     *                                {@code int}
+     * @throws IllegalArgumentException if {@code jsonPath} is null or empty
+     * @throws InvalidPathException     if the {@code jsonPath} expression is not valid
+     * @throws ConfigurationException   if not value found or the {@code jsonPath} expression
+     *                                  returns more than a single element
+     * @throws ClassCastException       if the {@code jsonPath} result cannot be assigned to
+     *                                  {@code int}
      * @since 0.4.0
      */
     @Override
@@ -162,11 +166,12 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
      * @return the {@code Long} object associated with the specified {@code jsonPath};
      *         {@code null} if not found
      *
-     * @throws InvalidPathException   if the {@code jsonPath} expression is not valid
-     * @throws ConfigurationException if the {@code jsonPath} expression returns more than a
-     *                                single element
-     * @throws ClassCastException     if the {@code jsonPath} result cannot be assigned to
-     *                                {@code long}
+     * @throws IllegalArgumentException if {@code jsonPath} is null or empty
+     * @throws InvalidPathException     if the {@code jsonPath} expression is not valid
+     * @throws ConfigurationException   if the {@code jsonPath} expression returns more than a
+     *                                  single element
+     * @throws ClassCastException       if the {@code jsonPath} result cannot be assigned to
+     *                                  {@code long}
      */
     @Override
     public Long getLong(String jsonPath)
@@ -183,11 +188,12 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
      * @return the {@code Long} object associated with the specified {@code jsonPath}; never
      *         {@code null}
      *
-     * @throws InvalidPathException   if the {@code jsonPath} expression is not valid
-     * @throws ConfigurationException if not value found or the {@code jsonPath} expression
-     *                                returns more than a single element
-     * @throws ClassCastException     if the {@code jsonPath} result cannot be assigned to
-     *                                {@code long}
+     * @throws IllegalArgumentException if {@code jsonPath} is null or empty
+     * @throws InvalidPathException     if the {@code jsonPath} expression is not valid
+     * @throws ConfigurationException   if not value found or the {@code jsonPath} expression
+     *                                  returns more than a single element
+     * @throws ClassCastException       if the {@code jsonPath} result cannot be assigned to
+     *                                  {@code long}
      * @since 0.4.0
      */
     @Override
@@ -205,11 +211,12 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
      * @return the {@code Double} object associated with the specified {@code jsonPath};
      *         {@code null} if not found
      *
-     * @throws InvalidPathException   if the {@code jsonPath} expression is not valid
-     * @throws ConfigurationException if the {@code jsonPath} expression returns more than a
-     *                                single element
-     * @throws ClassCastException     if the {@code jsonPath} result cannot be assigned to
-     *                                {@code double}
+     * @throws IllegalArgumentException if {@code jsonPath} is null or empty
+     * @throws InvalidPathException     if the {@code jsonPath} expression is not valid
+     * @throws ConfigurationException   if the {@code jsonPath} expression returns more than a
+     *                                  single element
+     * @throws ClassCastException       if the {@code jsonPath} result cannot be assigned to
+     *                                  {@code double}
      */
     @Override
     public Double getDouble(String jsonPath)
@@ -226,11 +233,12 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
      * @return the {@code Double} object associated with the specified {@code jsonPath}; never
      *         {@code null}
      *
-     * @throws InvalidPathException   if the {@code jsonPath} expression is not valid
-     * @throws ConfigurationException if not value found or the {@code jsonPath} expression
-     *                                returns more than a single element
-     * @throws ClassCastException     if the {@code jsonPath} result cannot be assigned to
-     *                                {@code double}
+     * @throws IllegalArgumentException if {@code jsonPath} is null or empty
+     * @throws InvalidPathException     if the {@code jsonPath} expression is not valid
+     * @throws ConfigurationException   if not value found or the {@code jsonPath} expression
+     *                                  returns more than a single element
+     * @throws ClassCastException       if the {@code jsonPath} result cannot be assigned to
+     *                                  {@code double}
      * @since 0.4.0
      */
     @Override
@@ -247,9 +255,10 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
      * @return the {@code String} object associated with the specified {@code jsonPath};
      *         {@code null} if not found
      *
-     * @throws InvalidPathException   if the {@code jsonPath} expression is not valid
-     * @throws ConfigurationException if the {@code jsonPath} expression returns more than a
-     *                                single element
+     * @throws IllegalArgumentException if {@code jsonPath} is null or empty
+     * @throws InvalidPathException     if the {@code jsonPath} expression is not valid
+     * @throws ConfigurationException   if the {@code jsonPath} expression returns more than a
+     *                                  single element
      */
     @Override
     public String getString(String jsonPath)
@@ -265,9 +274,10 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
      * @return the {@code String} value associated with the specified {@code jsonPath}; never
      *         {@code null}
      *
-     * @throws InvalidPathException   if the {@code jsonPath} expression is not valid
-     * @throws ConfigurationException if not value found or the {@code jsonPath} expression
-     *                                returns more than a single element
+     * @throws IllegalArgumentException if {@code jsonPath} is null or empty
+     * @throws InvalidPathException     if the {@code jsonPath} expression is not valid
+     * @throws ConfigurationException   if not value found or the {@code jsonPath} expression
+     *                                  returns more than a single element
      * @since 0.4.0
      */
     @Override
@@ -286,11 +296,12 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
      *
      * @return the mapped value associated with the specified {@code jsonPath}
      *
-     * @throws InvalidPathException   if the {@code jsonPath} expression is not valid
-     * @throws ConfigurationException if not value found or the {@code jsonPath} expression
-     *                                returns more than a single element
-     * @throws ClassCastException     if the {@code jsonPath} result cannot be assigned to the
-     *                                specified {@code targetType}
+     * @throws IllegalArgumentException if {@code jsonPath} is null or empty
+     * @throws InvalidPathException     if the {@code jsonPath} expression is not valid
+     * @throws ConfigurationException   if not value found or the {@code jsonPath} expression
+     *                                  returns more than a single element
+     * @throws ClassCastException       if the {@code jsonPath} result cannot be assigned to
+     *                                  the specified {@code targetType}
      * @since 0.4.0
      */
     protected <T> T getValue(String jsonPath, Class<T> targetType)
@@ -308,15 +319,16 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
      *
      * @return the mapped value associated with the specified {@code jsonPath}
      *
-     * @throws InvalidPathException   if the {@code jsonPath} expression is not valid
-     * @throws ConfigurationException if the {@code jsonPath} expression returns more than a
-     *                                single element
-     * @throws ClassCastException     if the {@code jsonPath} result cannot be assigned to the
-     *                                specified {@code targetType}
+     * @throws IllegalArgumentException if {@code jsonPath} is null or empty
+     * @throws InvalidPathException     if the {@code jsonPath} expression is not valid
+     * @throws ConfigurationException   if the {@code jsonPath} expression returns more than a
+     *                                  single element
+     * @throws ClassCastException       if the {@code jsonPath} result cannot be assigned to
+     *                                  the specified {@code targetType}
      */
     protected <T> T getValue(String jsonPath, Class<T> targetType, boolean mandatory)
     {
-        Object result = documentContext.read(jsonPath);
+        Object result = get(jsonPath);
         switch (jsonProvider.length(result))
         {
         case 0:
@@ -331,6 +343,27 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
         default:
             throw new ConfigurationException("Multiple values found for path: %s", jsonPath);
         }
+    }
+
+    /**
+     * Returns the object associated with the specified {@code key}.
+     * <p>
+     * <b>Note:</b> The actual return type may vary depending on the JSON implementation.
+     *
+     * @param jsonPath the path to read
+     *
+     * @return the object object associated with the specified {@code key}; {@code null} if
+     *         not found
+     *
+     * @throws IllegalArgumentException if {@code jsonPath} is null or empty
+     * @throws InvalidPathException     if the {@code jsonPath} expression is not valid
+     *
+     * @since 1.2.0
+     */
+    @Override
+    public Object get(String jsonPath)
+    {
+        return documentContext.read(jsonPath);
     }
 
 }

--- a/confectory-core/src/main/java/net/obvj/confectory/helper/GenericJsonConfigurationHelper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/helper/GenericJsonConfigurationHelper.java
@@ -74,7 +74,7 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
      *
      * @param jsonPath the path to read
      * @return the {@code Boolean} object associated with the specified {@code jsonPath};
-     *         {@code null} if not found
+     *         {@code null} if the path is not found
      *
      * @throws IllegalArgumentException if {@code jsonPath} is null or empty
      * @throws InvalidPathException     if the {@code jsonPath} expression is not valid
@@ -119,7 +119,7 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
      *
      * @param jsonPath the path to read
      * @return the {@code Integer} object associated with the specified {@code jsonPath};
-     *         {@code null} if not found
+     *         {@code null} if the path is not found
      *
      * @throws IllegalArgumentException if {@code jsonPath} is null or empty
      * @throws InvalidPathException     if the {@code jsonPath} expression is not valid
@@ -164,7 +164,7 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
      *
      * @param jsonPath the path to read
      * @return the {@code Long} object associated with the specified {@code jsonPath};
-     *         {@code null} if not found
+     *         {@code null} if the path is not found
      *
      * @throws IllegalArgumentException if {@code jsonPath} is null or empty
      * @throws InvalidPathException     if the {@code jsonPath} expression is not valid
@@ -209,7 +209,7 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
      *
      * @param jsonPath the path to read
      * @return the {@code Double} object associated with the specified {@code jsonPath};
-     *         {@code null} if not found
+     *         {@code null} if the path is not found
      *
      * @throws IllegalArgumentException if {@code jsonPath} is null or empty
      * @throws InvalidPathException     if the {@code jsonPath} expression is not valid
@@ -253,7 +253,7 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
      *
      * @param jsonPath the path to read
      * @return the {@code String} object associated with the specified {@code jsonPath};
-     *         {@code null} if not found
+     *         {@code null} if the path is found
      *
      * @throws IllegalArgumentException if {@code jsonPath} is null or empty
      * @throws InvalidPathException     if the {@code jsonPath} expression is not valid
@@ -346,14 +346,16 @@ public class GenericJsonConfigurationHelper<J> implements ConfigurationHelper<J>
     }
 
     /**
-     * Returns the object associated with the specified {@code key}.
+     * Returns the object associated with the specified @code jsonPath} in the JSON document
+     * in context.
      * <p>
-     * <b>Note:</b> The actual return type may vary depending on the JSON implementation.
+     * <b>Note:</b> The actual return type may vary depending on the JSON implementation, but
+     * usually it should be an array.
      *
      * @param jsonPath the path to read
      *
-     * @return the object object associated with the specified {@code key}; {@code null} if
-     *         not found
+     * @return the object associated with the specified {@code key}; or an empty array if the
+     *         path is not found
      *
      * @throws IllegalArgumentException if {@code jsonPath} is null or empty
      * @throws InvalidPathException     if the {@code jsonPath} expression is not valid

--- a/confectory-core/src/main/java/net/obvj/confectory/helper/NullConfigurationHelper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/helper/NullConfigurationHelper.java
@@ -40,6 +40,15 @@ public class NullConfigurationHelper<T> implements ConfigurationHelper<T>
     }
 
     /**
+     * @return {@code null}, always
+     */
+    @Override
+    public Object get(String key)
+    {
+        return null;
+    }
+
+    /**
      * @return {@code null}, always <b>(not to be interpreted as {@code false})</b>
      */
     @Override

--- a/confectory-core/src/main/java/net/obvj/confectory/helper/PropertiesConfigurationHelper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/helper/PropertiesConfigurationHelper.java
@@ -41,6 +41,13 @@ public class PropertiesConfigurationHelper extends BasicConfigurationHelper<Prop
     }
 
     @Override
+    public Object get(String key)
+    {
+        validateKey(key);
+        return super.bean.get(key);
+    }
+
+    @Override
     public String getString(String key)
     {
         return getValue(key);
@@ -59,8 +66,12 @@ public class PropertiesConfigurationHelper extends BasicConfigurationHelper<Prop
 
     protected String getValue(String key)
     {
-        Objects.requireNonNull(key, "The key must not be null");
+        validateKey(key);
         return super.bean.getProperty(key);
     }
 
+    private void validateKey(String key)
+    {
+        Objects.requireNonNull(key, "The key must not be null");
+    }
 }

--- a/confectory-core/src/main/java/net/obvj/confectory/mapper/PropertiesToObjectMapper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/mapper/PropertiesToObjectMapper.java
@@ -54,7 +54,6 @@ import net.obvj.confectory.util.Property;
  * assume a default value, i.e.: {@code null} for object types, zero for numeric types,
  * and {@code false} for booleans.</li>
  * </ul>
- * <p>
  *
  * @param <T> the target type to be produced by this {@code Mapper}
  *

--- a/confectory-core/src/test/java/net/obvj/confectory/ConfigurationTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/ConfigurationTest.java
@@ -103,6 +103,19 @@ class ConfigurationTest
     }
 
     @Test
+    void get_validKey_value()
+    {
+        // java.util.Properties doesn't convert strings
+        assertThat(CONFIG_PROPERTIES_1.get("myBool"), equalTo("true"));
+    }
+
+    @Test
+    void get_invalidKey_null()
+    {
+        assertThat(CONFIG_PROPERTIES_1.get(UNKNOWN), equalTo(null));
+    }
+
+    @Test
     void getString_validKey_value()
     {
         assertThat(CONFIG_PROPERTIES_1.getString("myKey"), equalTo("myValue"));

--- a/confectory-core/src/test/java/net/obvj/confectory/helper/BeanConfigurationHelperTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/helper/BeanConfigurationHelperTest.java
@@ -32,37 +32,43 @@ class BeanConfigurationHelperTest
     }
 
     @Test
-    void getBoolean_existingKey_true()
+    void get_existingKey_exception()
+    {
+        assertThat(() -> HELPER.get(KEY), CONFIGURATION_EXCEPTION_TYPE_NOT_SUPPORTED);
+    }
+
+    @Test
+    void getBoolean_existingKey_exception()
     {
         assertThat(() -> HELPER.getBoolean(KEY), CONFIGURATION_EXCEPTION_TYPE_NOT_SUPPORTED);
     }
 
     @Test
-    void getInteger_existingKey_zero()
+    void getInteger_existingKey_exception()
     {
         assertThat(() -> HELPER.getInteger(KEY), CONFIGURATION_EXCEPTION_TYPE_NOT_SUPPORTED);
     }
 
     @Test
-    void getLong_existingKey_zero()
+    void getLong_existingKey_exception()
     {
         assertThat(() -> HELPER.getLong(KEY), CONFIGURATION_EXCEPTION_TYPE_NOT_SUPPORTED);
     }
 
     @Test
-    void getDouble_existingKey_zero()
+    void getDouble_existingKey_exception()
     {
         assertThat(() -> HELPER.getDouble(KEY), CONFIGURATION_EXCEPTION_TYPE_NOT_SUPPORTED);
     }
 
     @Test
-    void getString_existingKey_empty()
+    void getString_existingKey_exception()
     {
         assertThat(() -> HELPER.getString(KEY), CONFIGURATION_EXCEPTION_TYPE_NOT_SUPPORTED);
     }
 
     @Test
-    void getMandatoryString_existingKey_empty()
+    void getMandatoryString_existingKey_exception()
     {
         assertThat(() -> HELPER.getMandatoryString(KEY), CONFIGURATION_EXCEPTION_TYPE_NOT_SUPPORTED);
     }

--- a/confectory-core/src/test/java/net/obvj/confectory/helper/GenericJsonConfigurationHelperTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/helper/GenericJsonConfigurationHelperTest.java
@@ -24,20 +24,20 @@ import net.obvj.confectory.ConfigurationException;
 @ExtendWith(MockitoExtension.class)
 class GenericJsonConfigurationHelperTest
 {
+    private static final JSONArray TEST_JSON_ARRAY1 = new JSONArray();
     private static final JSONObject TEST_JSON_SAMPLE1 = new JSONObject();
 
     static
     {
+        TEST_JSON_ARRAY1.add("element1");
+        TEST_JSON_ARRAY1.add("element2");
+
         TEST_JSON_SAMPLE1.put("intValue", 9);
         TEST_JSON_SAMPLE1.put("longValue", 9876543210L);
         TEST_JSON_SAMPLE1.put("booleanValue", true);
         TEST_JSON_SAMPLE1.put("stringValue", "test");
         TEST_JSON_SAMPLE1.put("doubleValue", 7.89);
-
-        JSONArray array = new JSONArray();
-        array.add("element1");
-        array.add("element2");
-        TEST_JSON_SAMPLE1.put("array", array);
+        TEST_JSON_SAMPLE1.put("array", TEST_JSON_ARRAY1);
     }
 
     private static final GenericJsonConfigurationHelper<JSONObject> HELPER = new JsonSmartConfigurationHelper(
@@ -51,6 +51,18 @@ class GenericJsonConfigurationHelperTest
     void getBean_notEmpty()
     {
         assertThat(HELPER.getBean(), is(sameInstance(TEST_JSON_SAMPLE1)));
+    }
+
+    @Test
+    void get_existingKey_success()
+    {
+        assertThat(HELPER.get("$.array[*]"), equalTo(TEST_JSON_ARRAY1));
+    }
+
+    @Test
+    void get_unknownKey_emptyArrays()
+    {
+        assertThat(HELPER.get(PATH_UNKNOWN), equalTo(new JSONArray()));
     }
 
     @Test

--- a/confectory-core/src/test/java/net/obvj/confectory/helper/GenericJsonConfigurationHelperTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/helper/GenericJsonConfigurationHelperTest.java
@@ -60,7 +60,7 @@ class GenericJsonConfigurationHelperTest
     }
 
     @Test
-    void get_unknownKey_emptyArrays()
+    void get_unknownKey_emptyArray()
     {
         assertThat(HELPER.get(PATH_UNKNOWN), equalTo(new JSONArray()));
     }

--- a/confectory-core/src/test/java/net/obvj/confectory/helper/NullConfigurationHelperTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/helper/NullConfigurationHelperTest.java
@@ -31,6 +31,12 @@ class NullConfigurationHelperTest
     }
 
     @Test
+    void get_anyKey_null()
+    {
+        assertNull(helper.get(KEY1));
+    }
+
+    @Test
     void getBoolean_anyKey_null()
     {
         assertNull(helper.getBoolean(KEY1));

--- a/confectory-datamapper-gson/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveGsonJsonToJsonObject.java
+++ b/confectory-datamapper-gson/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveGsonJsonToJsonObject.java
@@ -22,5 +22,7 @@ public class ConfectoryTestDriveGsonJsonToJsonObject
         System.out.println(config.getString("$.agents[0].interval"));
         System.out.println(config.getString("$.agents[1:].class"));
         System.out.println(config.getString("$.agents[?(@.class=='Agent2')].interval"));
+        System.out.println(config.get("$.agents.*.class"));
+        System.out.println(config.get("$.agents[0]"));
     }
 }

--- a/confectory-datamapper-jackson2-json/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveJacksonJsonToJsonNode.java
+++ b/confectory-datamapper-jackson2-json/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveJacksonJsonToJsonNode.java
@@ -19,5 +19,7 @@ public class ConfectoryTestDriveJacksonJsonToJsonNode
         System.out.println(config.getBoolean("enabled"));
         System.out.println(config.getString("$.agents[0].interval"));
         System.out.println(config.getString("$.agents[?(@.class=='Agent2')].interval"));
+        System.out.println(config.get("$.agents[*].class"));
+        System.out.println(config.get("$.agents[0]"));
     }
 }

--- a/confectory-datamapper-lite/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveXMLToJSONObject.java
+++ b/confectory-datamapper-lite/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveXMLToJSONObject.java
@@ -18,5 +18,7 @@ public class ConfectoryTestDriveXMLToJSONObject
         System.out.println(config.getBoolean("conf.enabled"));
         System.out.println(config.getString("**.agent[0].interval"));
         System.out.println(config.getString("$.conf.agents.agent[?(@.class=='Agent2')].interval"));
+        System.out.println(config.get("$.conf.agents"));
+        System.out.println(config.get("$.conf.agents.**.class"));
     }
 }

--- a/confectory-datamapper-snakeyaml/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveYAMLToJSONObject.java
+++ b/confectory-datamapper-snakeyaml/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveYAMLToJSONObject.java
@@ -21,6 +21,8 @@ public class ConfectoryTestDriveYAMLToJSONObject
         System.out.println(config.getString("$.contactDetails[?(@.type=='landline')].number"));
         System.out.println(config.getString("$.homeAddress.line"));
         System.out.println(config.getString("$.homeAddress.city"));
+        System.out.println(config.get("$.contactDetails[*].type"));
+        System.out.println(config.get("$.contactDetails[?(@.type=='landline')]"));
 
     }
 }


### PR DESCRIPTION
This enhancement introduces a method for retrieving raw JSON Objects and JSON Arrays from a JSONPath.

For example:

````json
{
  "firstName": "John",
  "lastName" : "doe",
  "phoneNumbers": [
    {
      "type"  : "iPhone",
      "number": "0123-4567-8888"
    },
    {
      "type"  : "home",
      "number": "0123-4567-8910"
    }
  ]
}
````

Once a Configuration is successfully loaded, the following call shall then be possible:

````java
System.out.println(config.get("$.phoneNumbers[*].type"));
//result: (JSONArray) [ "iPhone", "home" ]
````

The actual return type will vary depending on the underlying JSON implementation (e.g.: Jackson, json.org, json-smart, or Gson).