### PR TITLE
New INI-to-JSONObject Mapper

### DIFF
--- a/confectory-core/src/main/java/net/obvj/confectory/mapper/INIToJSONObjectMapper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/mapper/INIToJSONObjectMapper.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2022 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.obvj.confectory.mapper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import net.minidev.json.JSONObject;
+import net.minidev.json.JSONValue;
+import net.obvj.confectory.ConfigurationSourceException;
+import net.obvj.confectory.helper.ConfigurationHelper;
+import net.obvj.confectory.helper.JsonSmartConfigurationHelper;
+
+/**
+ * A specialized {@code Mapper} that loads the contents of a valid INI {@code Source}
+ * (e.g.: file, URL) as a {@link JSONObject}.
+ *
+ * @author oswaldo.bapvic.jr (Oswaldo Junior)
+ * @since 1.3.0
+ */
+public class INIToJSONObjectMapper implements Mapper<JSONObject>
+{
+    private static final char TOKEN_COMMENT_START = ';';
+    private static final char TOKEN_COMMENT_START_ALT = '#';
+    private static final char TOKEN_SECTION_NAME_START = '[';
+    private static final char TOKEN_SECTION_NAME_END = ']';
+    private static final String TOKEN_KEY_VALUE_DELIMITER = "=";
+
+    private static final String MSG_MALFORMED_INI = "Malformed INI: expected %s at line %s: \"%s\"";
+    private static final String ARG_SECTION_NAME = "section name";
+    private static final String ARG_PROPERTY_KEY = "property key";
+    private static final String ARG_PROPERTY = "property";
+    private static final String ARG_TOKEN = "token '%s'";
+
+    @Override
+    public JSONObject apply(InputStream inputStream) throws IOException
+    {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+        String currentLine = reader.readLine();
+        int number = 1;
+
+        JSONObject json = new JSONObject();
+        JSONObject section = json; // Let the final JSON be the initial section
+
+        while (currentLine != null)
+        {
+            currentLine = currentLine.trim();
+
+            if (currentLine.isEmpty() || isCommentLine(currentLine))
+            {
+                // Ignore empty and comment lines
+            }
+            else if (isSectionLine(currentLine))
+            {
+                String name = parseSectionName(currentLine, number);
+                section = new JSONObject(); // the current session, from now on
+                json.put(name, section);
+            }
+            else if (isPropertyLine(currentLine))
+            {
+                String key = parseKey(currentLine, number);
+                Object value = parseValue(currentLine);
+                section.put(key, value);
+            }
+            else
+            {
+                throw malformedIniException(ARG_PROPERTY, number, currentLine);
+            }
+
+            currentLine = reader.readLine();
+            number++;
+        }
+        return json;
+    }
+
+    private static boolean isCommentLine(String line)
+    {
+        char firstCharacter = line.charAt(0);
+        return firstCharacter == TOKEN_COMMENT_START || firstCharacter == TOKEN_COMMENT_START_ALT;
+    }
+
+    private static boolean isSectionLine(String line)
+    {
+        return line.charAt(0) == TOKEN_SECTION_NAME_START;
+    }
+
+    /**
+     * Parses the section name.
+     *
+     * @param line   the line to be parsed (cannot be null)
+     * @param number the line number for due exception reporting
+     * @return the section name
+     */
+    private static String parseSectionName(String line, int number)
+    {
+        int sectionNameDelimiterIndex = line.indexOf(TOKEN_SECTION_NAME_END);
+        if (sectionNameDelimiterIndex < 0)
+        {
+            throw malformedIniException(String.format(ARG_TOKEN, TOKEN_SECTION_NAME_END), number, line);
+        }
+        String name = line.substring(1, sectionNameDelimiterIndex);
+        if (name.isEmpty())
+        {
+            throw malformedIniException(ARG_SECTION_NAME, number, line);
+        }
+        return name;
+    }
+
+    private static boolean isPropertyLine(String line)
+    {
+        return line.contains(TOKEN_KEY_VALUE_DELIMITER);
+    }
+
+    private static String parseKey(String line, int number)
+    {
+        String key = line.substring(0, line.indexOf(TOKEN_KEY_VALUE_DELIMITER)).trim();
+        if (key.isEmpty())
+        {
+            throw malformedIniException(ARG_PROPERTY_KEY, number, line);
+        }
+        return key;
+    }
+
+    private static Object parseValue(String line)
+    {
+        String value = line.substring(line.indexOf(TOKEN_KEY_VALUE_DELIMITER) + 1).trim();
+        return JSONValue.parse(value); // return either null, number, boolean, or string
+    }
+
+    private static ConfigurationSourceException malformedIniException(String expected, int lineNumber, String line)
+    {
+        return new ConfigurationSourceException(MSG_MALFORMED_INI, expected, lineNumber, line);
+    }
+
+    @Override
+    public ConfigurationHelper<JSONObject> configurationHelper(JSONObject jsonObject)
+    {
+        return new JsonSmartConfigurationHelper(jsonObject);
+    }
+
+}

--- a/confectory-core/src/test/java/net/obvj/confectory/mapper/INIToJSONObjectMapperTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/mapper/INIToJSONObjectMapperTest.java
@@ -1,0 +1,136 @@
+package net.obvj.confectory.mapper;
+
+import static net.obvj.junit.utils.matchers.AdvancedMatchers.throwsException;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import net.minidev.json.JSONObject;
+import net.obvj.confectory.ConfigurationSourceException;
+import net.obvj.confectory.helper.JsonSmartConfigurationHelper;
+
+/**
+ * Unit tests for the {@link INIToJSONObjectMapper} class.
+ *
+ * @author oswaldo.bapvic.jr
+ * @since 1.3.0
+ */
+class INIToJSONObjectMapperTest
+{
+    private static final String VALID_INI_1    = ";Comment\n"
+                                               + "rootProperty = myRootValue\n"
+                                               + "\n"
+                                               + "[section1]\n"
+                                               + "# Alternative comment\n"
+                                               + "section_string = mySection1Value\n"
+                                               + "section_number = 1\n"
+                                               + "section_bool = false\n"
+                                               + "\n"
+                                               + "[section2]\n"
+                                               + "section_string = mySection2Value\n"
+                                               + "section_number = 2\n"
+                                               + "section_bool = true\n";
+
+    private static final String INVALID_INI_1  = ";Test with invalid section declaration\n"
+                                               + "[section1\n" // Missing token ']'
+                                               + "section_string = mySection1Value\n";
+
+    private static final String INVALID_INI_2  = ";Test with a missing section name\n"
+                                               + "[]\n"
+                                               + "section_string = mySection1Value\n";
+
+    private static final String INVALID_INI_3  = "=value\n";
+
+    private static final String INVALID_INI_4  = "invalid line\n";
+
+    private static final String VALID_INI_2    = "empty value = \n"; // this is OK
+
+    private Mapper<JSONObject> mapper = new INIToJSONObjectMapper();
+
+    private ByteArrayInputStream toInputStream(String content)
+    {
+        return new ByteArrayInputStream(content.getBytes());
+    }
+
+    private JSONObject testWithString(String string)
+    {
+        try
+        {
+            return mapper.apply(toInputStream(string));
+        }
+        catch (IOException exception)
+        {
+            fail("Test ended with an IOException, but this was not supposed to happen");
+            return null;
+        }
+    }
+
+    @Test
+    void apply_validIni_validJSONObject() throws IOException
+    {
+        JSONObject result = testWithString(VALID_INI_1);
+        assertThat(result.size(), equalTo(3));
+        assertThat(result.get("rootProperty"), equalTo("myRootValue"));
+
+        JSONObject section1 = (JSONObject) result.get("section1");
+        assertThat(section1.size(), equalTo(3));
+        assertThat(section1.get("section_string"), equalTo("mySection1Value"));
+        assertThat(section1.get("section_number"), equalTo(1));
+        assertThat(section1.get("section_bool"), equalTo(false));
+
+        JSONObject section2 = (JSONObject) result.get("section2");
+        assertThat(section2.size(), equalTo(3));
+        assertThat(section2.get("section_string"), equalTo("mySection2Value"));
+        assertThat(section2.get("section_number"), equalTo(2));
+        assertThat(section2.get("section_bool"), equalTo(true));
+    }
+
+    @Test
+    void apply_validIni2_validJSONObject() throws IOException
+    {
+        JSONObject result = testWithString(VALID_INI_2);
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get("empty value"), equalTo(""));
+    }
+
+    @Test
+    void apply_missingTokenInSectionDeclaration_exception() throws IOException
+    {
+        assertThat(() -> testWithString(INVALID_INI_1), throwsException(ConfigurationSourceException.class)
+                .withMessage(equalTo("Malformed INI: expected token ']' at line 2: \"[section1\"")));
+    }
+
+    @Test
+    void apply_sectionDeclarationNoName_exception() throws IOException
+    {
+        assertThat(() -> testWithString(INVALID_INI_2), throwsException(ConfigurationSourceException.class)
+                .withMessage(equalTo("Malformed INI: expected section name at line 2: \"[]\"")));
+    }
+
+    @Test
+    void apply_valueWithoutProperty_exception() throws IOException
+    {
+        assertThat(() -> testWithString(INVALID_INI_3), throwsException(ConfigurationSourceException.class)
+                .withMessage(equalTo("Malformed INI: expected property key at line 1: \"=value\"")));
+    }
+
+    @Test
+    void apply_invalidLine_exception() throws IOException
+    {
+        assertThat(() -> testWithString(INVALID_INI_4), throwsException(ConfigurationSourceException.class)
+                .withMessage(equalTo("Malformed INI: expected property at line 1: \"invalid line\"")));
+    }
+
+    @Test
+    void configurationHelper_smartJSONObjectConfigurationHelper()
+    {
+        assertThat(mapper.configurationHelper(new JSONObject()).getClass(),
+                equalTo(JsonSmartConfigurationHelper.class));
+    }
+
+}

--- a/confectory-core/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveINIToJSONObject.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveINIToJSONObject.java
@@ -1,0 +1,24 @@
+package net.obvj.confectory.testdrive;
+
+import net.minidev.json.JSONObject;
+import net.obvj.confectory.Configuration;
+import net.obvj.confectory.mapper.INIToJSONObjectMapper;
+
+public class ConfectoryTestDriveINIToJSONObject
+{
+    public static void main(String[] args)
+    {
+        Configuration<JSONObject> config = Configuration.<JSONObject>builder()
+                .source("testfiles/my-app.ini")
+                .mapper(new INIToJSONObjectMapper())
+                .build();
+
+        System.out.println(config.getBean());
+        System.out.println(config.getString("$.title"));
+        System.out.println(config.getString("$.owner.name"));
+        System.out.println(config.getDouble("$.owner.height"));
+        System.out.println(config.getInteger("$.database.port"));
+        System.out.println(config.getBoolean("$.database.read_only"));
+
+    }
+}

--- a/confectory-core/src/test/resources/testfiles/my-app.ini
+++ b/confectory-core/src/test/resources/testfiles/my-app.ini
@@ -1,0 +1,14 @@
+; last modified by John Doe
+title = my-app.ini
+
+[owner]
+name = John Doe
+organization = Acme Widgets Inc.
+height = 1.74
+
+[database]
+; use IP address in case network name resolution is not working
+server = 192.0.2.62     
+port = 143
+read_only=true
+mode=


### PR DESCRIPTION
## New feature

### Proposed solution

Introduce a new mapper `INIToJSONObjectMapper` for mapping INI sources as JSONObject (minidev's smart-json provider) inside `confectory-datamapper-core`.

### Examples of usage

#### Loading a INI file as JSONObject

##### Sample file (my-app.ini)

````ini
; last modified by John Doe
title = my-app.ini

[owner]
name = John Doe
organization = Acme Widgets Inc.
height = 1.74

[database]
; use IP address in case network name resolution is not working
server = 192.0.2.62     
port = 143
read_only=true
mode=
````

##### Code sample (desired):

```` java
Configuration config = Configuration.<JSONObject>builder() // minidev's smart-json
                                .source(new ClasspathFileSource<>("my-app.ini"))
                                .mapper(new INIToJSONObjectMapper())
                                .build();

config.getBean(); // returns a smart JSON object (assignable from HashMap)
config.getInteger("$.database.port"); // 143
````


## Quality criteria
The following criteria will be observed during the Code Review:

#### Code coverage
- The produced code shall be secured by unit tests.
- Test coverage shall remain the same or increase.

#### Documentation
- All methods shall be documented with **Javadoc**, providing examples of usage.
- Javadoc pages shall be compilable with no errors or warnings
- README.md shall be updated if applicable