### PR TITLE
New INI-to-object Mapper

### DIFF
--- a/confectory-core/src/main/java/net/obvj/confectory/mapper/AbstractINIMapper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/mapper/AbstractINIMapper.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2022 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.obvj.confectory.mapper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import net.obvj.confectory.ConfigurationSourceException;
+
+/**
+ * An abstract {@code Mapper} that defines a template of how to parse the contents of a
+ * valid INI {@code Source} (e.g.: file, URL), and delegates the final object type
+ * population to a concrete implementation.
+ *
+ * @author oswaldo.bapvic.jr (Oswaldo Junior)
+ * @since 1.3.0
+ */
+public abstract class AbstractINIMapper<T> implements Mapper<T>
+{
+    private static final char TOKEN_COMMENT_START = ';';
+    private static final char TOKEN_COMMENT_START_ALT = '#';
+    private static final char TOKEN_SECTION_NAME_START = '[';
+    private static final char TOKEN_SECTION_NAME_END = ']';
+    private static final String TOKEN_KEY_VALUE_DELIMITER = "=";
+    private static final String MSG_MALFORMED_INI = "Malformed INI: expected %s at line %s: \"%s\"";
+    private static final String ARG_SECTION_NAME = "section name";
+    private static final String ARG_PROPERTY_KEY = "property key";
+    private static final String ARG_PROPERTY = "property";
+    private static final String ARG_TOKEN = "token '%s'";
+
+    protected String currentLine;
+    protected String currentSectionName;
+    protected Object currentSection;
+    protected String currentKey;
+    protected int currentLineNumber = 0;
+
+    /**
+     * A template method that defines the skeleton of the INI source parsing operation and
+     * delegates the final output mapping behavior to its concrete implementations.
+     *
+     * @param inputStream the {@code InputStream} to be read
+     * @return the parsed object
+     * @throws IOException if a low-level I/O problem (such and unexpected end-of-input, or
+     *                     network error) occurs while reading from the {@code InputStream}
+     */
+    protected Object doApply(InputStream inputStream) throws IOException
+    {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+        currentLine = reader.readLine();
+        currentLineNumber = 1;
+        currentSectionName = null;
+
+        Object out = newObject();
+        currentSection = out; // Let the final out be the initial section
+        boolean skipSection = false;
+
+        while (currentLine != null)
+        {
+            currentLine = currentLine.trim();
+
+            if (currentLine.isEmpty() || isCommentLine())
+            {
+                // Ignore empty and comment lines
+            }
+            else if (isSectionLine())
+            {
+                skipSection = false;
+                currentSectionName = parseSectionName();
+                currentSection = newObject(); // the current session, from now on
+                if (currentSection == null)
+                {
+                    skipSection = true; // flag to skip next properties until the next section declaration
+                }
+                else
+                {
+                    put(out, currentSectionName, currentSection);
+                }
+            }
+            else if (isPropertyLine())
+            {
+                if (!skipSection)
+                {
+                    currentKey = parseKey();
+                    Object value = parseValue();
+                    put(currentSection, currentKey, value);
+                }
+                // Do not process any property until the next section declaration
+            }
+            else
+            {
+                throw malformedIniException(ARG_PROPERTY);
+            }
+
+            currentLine = reader.readLine();
+            currentLineNumber++;
+        }
+        return out;
+    }
+
+    /**
+     * @return {@code true} if the current line starts with one of the comment tokens
+     */
+    private boolean isCommentLine()
+    {
+        char firstCharacter = currentLine.charAt(0);
+        return firstCharacter == TOKEN_COMMENT_START || firstCharacter == TOKEN_COMMENT_START_ALT;
+    }
+
+    /**
+     * @return {@code true} if the current line starts with {@link #TOKEN_SECTION_NAME_START}
+     */
+    private boolean isSectionLine()
+    {
+        return currentLine.charAt(0) == TOKEN_SECTION_NAME_START;
+    }
+
+    /**
+     * Parses the section name.
+     *
+     * @param line   the line to be parsed (cannot be null)
+     * @param currentLineNumber the line number for due exception reporting
+     * @return the section name
+     */
+    private String parseSectionName()
+    {
+        int sectionNameDelimiterIndex = currentLine.indexOf(TOKEN_SECTION_NAME_END);
+        if (sectionNameDelimiterIndex < 0)
+        {
+            throw malformedIniException(String.format(ARG_TOKEN, TOKEN_SECTION_NAME_END));
+        }
+        String name = currentLine.substring(1, sectionNameDelimiterIndex);
+        if (name.isEmpty())
+        {
+            throw malformedIniException(ARG_SECTION_NAME);
+        }
+        return name;
+    }
+
+    /**
+     * @return true if the current line contains the {@link #TOKEN_KEY_VALUE_DELIMITER}
+     */
+    private boolean isPropertyLine()
+    {
+        return currentLine.contains(TOKEN_KEY_VALUE_DELIMITER);
+    }
+
+    /**
+     * @return the key part of the current line, provided that it's a property line
+     */
+    private String parseKey()
+    {
+        String key = currentLine.substring(0, currentLine.indexOf(TOKEN_KEY_VALUE_DELIMITER)).trim();
+        if (key.isEmpty())
+        {
+            throw malformedIniException(ARG_PROPERTY_KEY);
+        }
+        return key;
+    }
+
+    /**
+     * @return the value part of the current line, provided that it's a propertly line
+     */
+    private Object parseValue()
+    {
+        String value = currentLine.substring(currentLine.indexOf(TOKEN_KEY_VALUE_DELIMITER) + 1).trim();
+        return doParseValue(value);
+    }
+
+    /**
+     * Create a new {@link ConfigurationSourceException} with a formatted message, containing
+     * also the current line text and number.
+     *
+     * @param expected a description of what was expected
+     * @return a new {@link ConfigurationSourceException} with a formatted message
+     */
+    private ConfigurationSourceException malformedIniException(String expected)
+    {
+        return new ConfigurationSourceException(MSG_MALFORMED_INI, expected, currentLineNumber, currentLine);
+    }
+
+    /**
+     * Creates a new container object that can accept names and values parsed from the source.
+     *
+     * @return an object that can represent either the final document or a specific section
+     */
+    abstract Object newObject();
+
+    /**
+     * Parse the specified text value into Java Object.
+     *
+     * @param value the value to be parsed
+     * @return the parsed Java Object
+     */
+    abstract Object doParseValue(String value);
+
+    /**
+     * Associates the specified value with the specified name in the specified target object.
+     *
+     * @param target the object in which the specified name and value shall be set
+     * @param name   the name to be set
+     * @param value  the value to be set
+     */
+    abstract void put(Object target, String name, Object value);
+
+}

--- a/confectory-core/src/main/java/net/obvj/confectory/mapper/INIToJSONObjectMapper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/mapper/INIToJSONObjectMapper.java
@@ -16,142 +16,53 @@
 
 package net.obvj.confectory.mapper;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 
 import net.minidev.json.JSONObject;
 import net.minidev.json.JSONValue;
-import net.obvj.confectory.ConfigurationSourceException;
 import net.obvj.confectory.helper.ConfigurationHelper;
 import net.obvj.confectory.helper.JsonSmartConfigurationHelper;
 
 /**
  * A specialized {@code Mapper} that loads the contents of a valid INI {@code Source}
  * (e.g.: file, URL) as a {@link JSONObject}.
+ * <p>
+ * <strong>Note:</strong> This mapper is <b>NOT</b> thread-safe.
  *
  * @author oswaldo.bapvic.jr (Oswaldo Junior)
  * @since 1.3.0
  */
-public class INIToJSONObjectMapper implements Mapper<JSONObject>
+public class INIToJSONObjectMapper extends AbstractINIMapper<JSONObject> implements Mapper<JSONObject>
 {
-    private static final char TOKEN_COMMENT_START = ';';
-    private static final char TOKEN_COMMENT_START_ALT = '#';
-    private static final char TOKEN_SECTION_NAME_START = '[';
-    private static final char TOKEN_SECTION_NAME_END = ']';
-    private static final String TOKEN_KEY_VALUE_DELIMITER = "=";
-
-    private static final String MSG_MALFORMED_INI = "Malformed INI: expected %s at line %s: \"%s\"";
-    private static final String ARG_SECTION_NAME = "section name";
-    private static final String ARG_PROPERTY_KEY = "property key";
-    private static final String ARG_PROPERTY = "property";
-    private static final String ARG_TOKEN = "token '%s'";
-
     @Override
     public JSONObject apply(InputStream inputStream) throws IOException
     {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
-        String currentLine = reader.readLine();
-        int number = 1;
-
-        JSONObject json = new JSONObject();
-        JSONObject section = json; // Let the final JSON be the initial section
-
-        while (currentLine != null)
-        {
-            currentLine = currentLine.trim();
-
-            if (currentLine.isEmpty() || isCommentLine(currentLine))
-            {
-                // Ignore empty and comment lines
-            }
-            else if (isSectionLine(currentLine))
-            {
-                String name = parseSectionName(currentLine, number);
-                section = new JSONObject(); // the current session, from now on
-                json.put(name, section);
-            }
-            else if (isPropertyLine(currentLine))
-            {
-                String key = parseKey(currentLine, number);
-                Object value = parseValue(currentLine);
-                section.put(key, value);
-            }
-            else
-            {
-                throw malformedIniException(ARG_PROPERTY, number, currentLine);
-            }
-
-            currentLine = reader.readLine();
-            number++;
-        }
-        return json;
-    }
-
-    private static boolean isCommentLine(String line)
-    {
-        char firstCharacter = line.charAt(0);
-        return firstCharacter == TOKEN_COMMENT_START || firstCharacter == TOKEN_COMMENT_START_ALT;
-    }
-
-    private static boolean isSectionLine(String line)
-    {
-        return line.charAt(0) == TOKEN_SECTION_NAME_START;
-    }
-
-    /**
-     * Parses the section name.
-     *
-     * @param line   the line to be parsed (cannot be null)
-     * @param number the line number for due exception reporting
-     * @return the section name
-     */
-    private static String parseSectionName(String line, int number)
-    {
-        int sectionNameDelimiterIndex = line.indexOf(TOKEN_SECTION_NAME_END);
-        if (sectionNameDelimiterIndex < 0)
-        {
-            throw malformedIniException(String.format(ARG_TOKEN, TOKEN_SECTION_NAME_END), number, line);
-        }
-        String name = line.substring(1, sectionNameDelimiterIndex);
-        if (name.isEmpty())
-        {
-            throw malformedIniException(ARG_SECTION_NAME, number, line);
-        }
-        return name;
-    }
-
-    private static boolean isPropertyLine(String line)
-    {
-        return line.contains(TOKEN_KEY_VALUE_DELIMITER);
-    }
-
-    private static String parseKey(String line, int number)
-    {
-        String key = line.substring(0, line.indexOf(TOKEN_KEY_VALUE_DELIMITER)).trim();
-        if (key.isEmpty())
-        {
-            throw malformedIniException(ARG_PROPERTY_KEY, number, line);
-        }
-        return key;
-    }
-
-    private static Object parseValue(String line)
-    {
-        String value = line.substring(line.indexOf(TOKEN_KEY_VALUE_DELIMITER) + 1).trim();
-        return JSONValue.parse(value); // return either null, number, boolean, or string
-    }
-
-    private static ConfigurationSourceException malformedIniException(String expected, int lineNumber, String line)
-    {
-        return new ConfigurationSourceException(MSG_MALFORMED_INI, expected, lineNumber, line);
+        return (JSONObject) doApply(inputStream);
     }
 
     @Override
-    public ConfigurationHelper<JSONObject> configurationHelper(JSONObject jsonObject)
+    Object newObject()
     {
-        return new JsonSmartConfigurationHelper(jsonObject);
+        return new JSONObject();
+    }
+
+    @Override
+    Object doParseValue(String value)
+    {
+        return JSONValue.parse(value); // return either null, number, boolean, or string
+    }
+
+    @Override
+    void put(Object target, String name, Object value)
+    {
+        ((JSONObject) target).put(name, value);
+    }
+
+    @Override
+    public ConfigurationHelper<JSONObject> configurationHelper(JSONObject object)
+    {
+        return new JsonSmartConfigurationHelper(object);
     }
 
 }

--- a/confectory-core/src/main/java/net/obvj/confectory/mapper/INIToJSONObjectMapper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/mapper/INIToJSONObjectMapper.java
@@ -28,7 +28,7 @@ import net.obvj.confectory.helper.JsonSmartConfigurationHelper;
  * A specialized {@code Mapper} that loads the contents of a valid INI {@code Source}
  * (e.g.: file, URL) as a {@link JSONObject}.
  * <p>
- * <strong>Note:</strong> This mapper is <b>NOT</b> thread-safe.
+ * <strong>Important:</strong> This mapper is <b>NOT</b> thread-safe.
  *
  * @author oswaldo.bapvic.jr (Oswaldo Junior)
  * @since 1.3.0

--- a/confectory-core/src/main/java/net/obvj/confectory/mapper/INIToObjectMapper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/mapper/INIToObjectMapper.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2022 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.obvj.confectory.mapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import org.apache.commons.lang3.reflect.ConstructorUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
+
+import net.obvj.confectory.ConfigurationException;
+import net.obvj.confectory.helper.BeanConfigurationHelper;
+import net.obvj.confectory.helper.ConfigurationHelper;
+import net.obvj.confectory.util.ParseFactory;
+import net.obvj.confectory.util.Property;
+import net.obvj.confectory.util.ReflectionUtils;
+
+/**
+ * A specialized {@code Mapper} that loads the contents of a valid INI {@code Source}
+ * (e.g.: file, URL) into a POJO (Plain-Old Java Object).
+ * <p>
+ * <strong>Note:</strong> This mapper is <b>NOT</b> thread-safe.
+ *
+ * @author oswaldo.bapvic.jr (Oswaldo Junior)
+ * @since 1.3.0
+ */
+public class INIToObjectMapper<T> extends AbstractINIMapper<T> implements Mapper<T>
+{
+    private static final String MSG_UNABLE_TO_BUILD_OBJECT = "Unable to build object of type: %s";
+
+    private final Class<T> targetType;
+
+    /**
+     * Builds a new {@code INIToObjectMapper} with the specified target type.
+     *
+     * @param targetType the target type to be produced by this {@code Mapper}
+     */
+    public INIToObjectMapper(Class<T> targetType)
+    {
+        this.targetType = targetType;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T apply(InputStream inputStream) throws IOException
+    {
+        return (T) doApply(inputStream);
+    }
+
+    @Override
+    Object newObject()
+    {
+        Class<?> type = getCurrentType();
+        try
+        {
+            return type != null ? ConstructorUtils.invokeConstructor(type) : null;
+        }
+        catch (ReflectiveOperationException exception)
+        {
+            throw new ConfigurationException(exception, MSG_UNABLE_TO_BUILD_OBJECT, type);
+        }
+    }
+
+    @Override
+    Object doParseValue(String value)
+    {
+        Field field = findField(getCurrentType(), currentKey);
+        return field != null ? ParseFactory.parse(field.getType(), value) : null;
+    }
+
+    @Override
+    void put(Object target, String name, Object value)
+    {
+        Field field = findField(target.getClass(), name);
+        if (field != null && !ReflectionUtils.isTransient(field))
+        {
+            try
+            {
+                FieldUtils.writeDeclaredField(target, field.getName(), value, true);
+            }
+            catch (IllegalAccessException exception)
+            {
+                throw new ConfigurationException(exception, MSG_UNABLE_TO_BUILD_OBJECT, target);
+            }
+        }
+    }
+
+    /**
+     * @return the current type being processed by the template, which can be either the final
+     *         {@code targetType}, or the current section type; or {@code null} if the current
+     *         section does not have a corresponing field in the final {@code targetType}
+     */
+    private Class<?> getCurrentType()
+    {
+        if (currentSectionName == null)
+        {
+            return targetType;
+        }
+        Field field = findField(targetType, currentSectionName);
+        return field != null ? field.getType() : null;
+    }
+
+    /**
+     * Find a field matching any of the following criteria in the specified type, or
+     * {@code null} if no match found:
+     * <ul>
+     * <li>the field name is equal to the specified {@code name} parameter; or</li>
+     * <li>the field is marked with the {@code @}{@link Property} annotation, and the
+     * annotation defines a custom name equal to the one specified in the parameter</li>
+     * </ul>
+     *
+     * @param type the class to reflect; not null
+     * @param name the field name to obtain; not null
+     * @return the {@link Field} object; can be null
+     */
+    private static Field findField(Class<?> type, String name)
+    {
+        return Optional.ofNullable(FieldUtils.getField(type, name, true))
+                .orElseGet(() -> findFieldByAnnotation(type, name).orElse(null));
+    }
+
+    /**
+     * Find a field matching the following criteria in the specified type, or {@code null} if
+     * no match found:
+     * <ul>
+     * <li>the field is marked with the {@code @}{@link Property} annotation, and the
+     * annotation defines a custom name equal to the one specified in the parameter</li>
+     * </ul>
+     *
+     * @param type the class to reflect; not null
+     * @param name the field name to obtain; not null
+     * @return an Optional possibly containing a {@link Field} object; can be empty
+     */
+    private static Optional<Field> findFieldByAnnotation(Class<?> type, String name)
+    {
+        return FieldUtils.getFieldsListWithAnnotation(type, Property.class).stream()
+                .filter(field -> isFieldAnnotated(field, name)).findAny();
+    }
+
+    /**
+     * Returns {@code true} if the field is annotated with a Property annotation which value
+     * matches the specified name.
+     *
+     * @param field the field to be checked
+     * @param name  the name to be tested
+     * @return {@code true} if the field is annotated with a Property annotation which value
+     *         matches the specified name
+     */
+    private static boolean isFieldAnnotated(Field field, String name)
+    {
+        Property property = field.getDeclaredAnnotation(Property.class);
+        return property != null && name.equals(property.value());
+    }
+
+    @Override
+    public ConfigurationHelper<T> configurationHelper(T object)
+    {
+        return new BeanConfigurationHelper<>(object);
+    }
+
+}

--- a/confectory-core/src/main/java/net/obvj/confectory/mapper/INIToObjectMapper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/mapper/INIToObjectMapper.java
@@ -43,7 +43,7 @@ import net.obvj.confectory.util.ReflectionUtils;
 public class INIToObjectMapper<T> extends AbstractINIMapper<T> implements Mapper<T>
 {
     private static final String MSG_UNABLE_TO_BUILD_OBJECT = "Unable to build object of type: %s";
-    private static final String MSG_UNPARSABLE_PROPERTY_VALUE = "The property %s does not contain a parsable %s";
+    private static final String MSG_UNPARSABLE_PROPERTY_VALUE = "The value defined for property %s cannot be parsed as '%s'";
 
     private final Class<T> targetType;
 
@@ -68,9 +68,21 @@ public class INIToObjectMapper<T> extends AbstractINIMapper<T> implements Mapper
     Object newObject()
     {
         Class<?> type = getCurrentType();
+        return type != null ? newObject(type) : null;
+    }
+
+    /**
+     * Returns a new instance of the specified class by invoking the default constructor.
+     *
+     * @param type the type to be instantiated
+     * @return a new instance
+     * @throws ConfigurationException in the occurrence of any reflective-operation exception
+     */
+    private Object newObject(Class<?> type)
+    {
         try
         {
-            return type != null ? ConstructorUtils.invokeConstructor(type) : null;
+            return ConstructorUtils.invokeConstructor(type);
         }
         catch (ReflectiveOperationException exception)
         {

--- a/confectory-core/src/main/java/net/obvj/confectory/mapper/INIToObjectMapper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/mapper/INIToObjectMapper.java
@@ -104,7 +104,7 @@ public class INIToObjectMapper<T> extends AbstractINIMapper<T> implements Mapper
     /**
      * @return the current type being processed by the template, which can be either the final
      *         {@code targetType}, or the current section type; or {@code null} if the current
-     *         section does not have a corresponing field in the final {@code targetType}
+     *         section does not have a corresponding field in the final {@code targetType}
      */
     private Class<?> getCurrentType()
     {
@@ -157,8 +157,8 @@ public class INIToObjectMapper<T> extends AbstractINIMapper<T> implements Mapper
      * Returns {@code true} if the field is annotated with a Property annotation which value
      * matches the specified name.
      *
-     * @param field the field to be checked
-     * @param name  the name to be tested
+     * @param field the field to be checked; not null
+     * @param name  the name to be tested; not null
      * @return {@code true} if the field is annotated with a Property annotation which value
      *         matches the specified name
      */

--- a/confectory-core/src/main/java/net/obvj/confectory/mapper/INIToObjectMapper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/mapper/INIToObjectMapper.java
@@ -35,7 +35,29 @@ import net.obvj.confectory.util.ReflectionUtils;
  * A specialized {@code Mapper} that loads the contents of a valid INI {@code Source}
  * (e.g.: file, URL) into a POJO (Plain-Old Java Object).
  * <p>
- * <strong>Note:</strong> This mapper is <b>NOT</b> thread-safe.
+ * Every property and section will be assigned to a field in the target object in either
+ * of the following cases:
+ * <ul>
+ * <li>the field is marked with the {@code @}{@link Property} annotation, defining a
+ * custom key to be mapped; or</li>
+ * <li>the field name is equal to the property key (with no need to use an annotation in
+ * these cases)</li>
+ * </ul>
+ * <p>
+ * <strong>Notes:</strong>
+ * <ul>
+ * <li>The fields in the target object can be {@code private} (recommended)</li>
+ * <li>Fields marked {@code transient} are ignored</li>
+ * <li>If the associated property is missing in the source, the corresponding field will
+ * assume a default value, i.e.: {@code null} for object types, zero for numeric types,
+ * and {@code false} for booleans.</li>
+ * <li>If the a section is not mapped to dedicated object in the target class, the whole
+ * section will be skipped</li>
+ * </ul>
+ * <p>
+ * <strong>Important:</strong> This mapper is <b>NOT</b> thread-safe.
+ *
+ * @param <T> the target type to be produced by this {@code Mapper}
  *
  * @author oswaldo.bapvic.jr (Oswaldo Junior)
  * @since 1.3.0

--- a/confectory-core/src/main/java/net/obvj/confectory/mapper/Mapper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/mapper/Mapper.java
@@ -34,7 +34,7 @@ public interface Mapper<T>
     /**
      * Applies this {@code Mapper} into the given input.
      * <p>
-     * <strong>Note:</strong>The input stream must be closed by the caller after the mapping
+     * <strong>Note:</strong> The input stream must be closed by the caller after the mapping
      * operation.
      *
      * @param input the input stream to be mapped

--- a/confectory-core/src/main/java/net/obvj/confectory/mapper/PropertiesToObjectMapper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/mapper/PropertiesToObjectMapper.java
@@ -19,7 +19,6 @@ package net.obvj.confectory.mapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.Properties;
 
 import org.apache.commons.lang3.StringUtils;
@@ -31,6 +30,7 @@ import net.obvj.confectory.helper.BeanConfigurationHelper;
 import net.obvj.confectory.helper.ConfigurationHelper;
 import net.obvj.confectory.util.ParseFactory;
 import net.obvj.confectory.util.Property;
+import net.obvj.confectory.util.ReflectionUtils;
 
 /**
  * A specialized {@code Mapper} that loads the contents of a {@code Source} (e.g.: file,
@@ -119,7 +119,7 @@ public class PropertiesToObjectMapper<T> implements Mapper<T>
      */
     private void writeField(T targetObject, Field field, Properties properties) throws IllegalAccessException
     {
-        if (isTransient(field))
+        if (ReflectionUtils.isTransient(field))
         {
             return; // Ignore transient fields
         }
@@ -132,19 +132,6 @@ public class PropertiesToObjectMapper<T> implements Mapper<T>
             FieldUtils.writeDeclaredField(targetObject, field.getName(), parsedValue, true);
         }
         // Do nothing if the property is not found
-    }
-
-    /**
-     * Evaluates if the specified field is marked {@code transient}.
-     *
-     * @param field the {@link Field} to be evaluated
-     * @return {@code true} if the field contains the {@code transient} modifier;
-     *         {@code false}, otherwise
-     * @throws NullPointerException if the field is null
-     */
-    private static boolean isTransient(Field field)
-    {
-        return Modifier.isTransient(field.getModifiers());
     }
 
     /**

--- a/confectory-core/src/main/java/net/obvj/confectory/util/ParseFactory.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/util/ParseFactory.java
@@ -43,7 +43,7 @@ public class ParseFactory
         factory.put(Long.class, Long::valueOf);
         factory.put(Float.class, Float::valueOf);
         factory.put(Double.class, Double::valueOf);
-        factory.put(Character.class, string -> Character.valueOf(string.charAt(0)));
+        factory.put(Character.class, string -> string.isEmpty() ? 0 : Character.valueOf(string.charAt(0)));
         factory.put(String.class, Function.identity());
     }
 

--- a/confectory-core/src/main/java/net/obvj/confectory/util/ReflectionUtils.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/util/ReflectionUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.obvj.confectory.util;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+/**
+ * Common methods for working with reflections.
+ *
+ * @author oswaldo.bapvic.jr (Oswaldo Junior)
+ * @since 1.3.0
+ */
+public class ReflectionUtils
+{
+
+    private ReflectionUtils()
+    {
+        throw new IllegalStateException("Instantiation not allowed");
+    }
+
+    /**
+     * Evaluates if the specified field is marked {@code transient}.
+     *
+     * @param field the {@link Field} to be evaluated
+     * @return {@code true} if the field contains the {@code transient} modifier;
+     *         {@code false}, otherwise
+     * @throws NullPointerException if the field is null
+     */
+    public static boolean isTransient(Field field)
+    {
+        return Modifier.isTransient(field.getModifiers());
+    }
+}

--- a/confectory-core/src/test/java/net/obvj/confectory/mapper/INIToObjectMapperTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/mapper/INIToObjectMapperTest.java
@@ -1,0 +1,145 @@
+package net.obvj.confectory.mapper;
+
+import static net.obvj.junit.utils.matchers.AdvancedMatchers.throwsException;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import net.obvj.confectory.ConfigurationSourceException;
+import net.obvj.confectory.helper.BeanConfigurationHelper;
+import net.obvj.confectory.mapper.model.MyIni;
+
+/**
+ * Unit tests for the {@link INIToJObjectMapper} class.
+ *
+ * @author oswaldo.bapvic.jr
+ * @since 1.3.0
+ */
+class INIToObjectMapperTest
+{
+    private static final String VALID_INI_1    = ";Comment\n"
+                                               + "rootProperty = myRootValue\n"
+                                               + "\n"
+                                               + "[section1]\n"
+                                               + "# Alternative comment\n"
+                                               + "section_string = mySection1Value\n"
+                                               + "section_number = 1\n"
+                                               + "section_bool = false\n"
+                                               + "\n"
+                                               + "[section2]\n"
+                                               + "section_string = mySection2Value\n"
+                                               + "section_number = 2\n"
+                                               + "section_bool = true\n";
+
+    private static final String INVALID_INI_1  = ";Test with invalid section declaration\n"
+                                               + "[section1\n" // Missing token ']'
+                                               + "section_string = mySection1Value\n";
+
+    private static final String INVALID_INI_2  = ";Test with a missing section name\n"
+                                               + "[]\n"
+                                               + "section_string = mySection1Value\n";
+
+    private static final String INVALID_INI_3 = "=value\n";
+
+    private static final String INVALID_INI_4 = "invalid line\n";
+
+    private static final String INVALID_INI_5 = ";Comment\n"
+                                              + "rootProperty = myRootValue\n"
+                                              + "\n"
+                                              + "[section3]\n" // Unmapped, the children properties shall be skipped
+                                              + "# Alternative comment\n"
+                                              + "section_string = mySection1Value\n"
+                                              + "section_number = 1\n"
+                                              + "section_bool = false\n"
+                                              + "\n"
+                                              + "[section2]\n"
+                                              + "section_string = mySection2Value\n"
+                                              + "section_number = 2\n"
+                                              + "section_bool = true\n";
+;
+
+    private Mapper<MyIni> mapper = new INIToObjectMapper<>(MyIni.class);
+
+    private ByteArrayInputStream toInputStream(String content)
+    {
+        return new ByteArrayInputStream(content.getBytes());
+    }
+
+    private MyIni testWithString(String string)
+    {
+        try
+        {
+            return mapper.apply(toInputStream(string));
+        }
+        catch (IOException exception)
+        {
+            fail("Test ended with an IOException, but this was not supposed to happen");
+            return null;
+        }
+    }
+
+    @Test
+    void apply_validIni_validJSONObject() throws IOException
+    {
+        MyIni result = testWithString(VALID_INI_1);
+        assertThat(result.getRootProperty(), is(equalTo("myRootValue")));
+        assertThat(result.getSection1().getSectionString(), is(equalTo("mySection1Value")));
+        assertThat(result.getSection1().getSectionNumber(), is(equalTo(1)));
+        assertThat(result.getSection1().isSectionBoolean(), is(equalTo(false)));
+        assertThat(result.getSection2().getSectionString(), is(equalTo("mySection2Value")));
+        assertThat(result.getSection2().getSectionNumber(), is(equalTo(2)));
+        assertThat(result.getSection2().isSectionBoolean(), is(equalTo(true)));
+    }
+
+    @Test
+    void apply_missingTokenInSectionDeclaration_exception() throws IOException
+    {
+        assertThat(() -> testWithString(INVALID_INI_1), throwsException(ConfigurationSourceException.class)
+                .withMessage(equalTo("Malformed INI: expected token ']' at line 2: \"[section1\"")));
+    }
+
+    @Test
+    void apply_sectionDeclarationNoName_exception() throws IOException
+    {
+        assertThat(() -> testWithString(INVALID_INI_2), throwsException(ConfigurationSourceException.class)
+                .withMessage(equalTo("Malformed INI: expected section name at line 2: \"[]\"")));
+    }
+
+    @Test
+    void apply_valueWithoutProperty_exception() throws IOException
+    {
+        assertThat(() -> testWithString(INVALID_INI_3), throwsException(ConfigurationSourceException.class)
+                .withMessage(equalTo("Malformed INI: expected property key at line 1: \"=value\"")));
+    }
+
+    @Test
+    void apply_invalidLine_exception() throws IOException
+    {
+        assertThat(() -> testWithString(INVALID_INI_4), throwsException(ConfigurationSourceException.class)
+                .withMessage(equalTo("Malformed INI: expected property at line 1: \"invalid line\"")));
+    }
+
+    @Test
+    void apply_sectionNotMapped_sectionSkipped() throws IOException
+    {
+        MyIni result = testWithString(INVALID_INI_5);
+        assertThat(result.getRootProperty(), is(equalTo("myRootValue")));
+        assertThat(result.getSection1(), is(equalTo(null)));
+        assertThat(result.getSection2().getSectionString(), is(equalTo("mySection2Value")));
+        assertThat(result.getSection2().getSectionNumber(), is(equalTo(2)));
+        assertThat(result.getSection2().isSectionBoolean(), is(equalTo(true)));
+    }
+
+    @Test
+    void configurationHelper_beanConfigurationHelper()
+    {
+        assertThat(mapper.configurationHelper(new MyIni()).getClass(), equalTo(BeanConfigurationHelper.class));
+    }
+
+}

--- a/confectory-core/src/test/java/net/obvj/confectory/mapper/INIToObjectMapperTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/mapper/INIToObjectMapperTest.java
@@ -158,7 +158,7 @@ class INIToObjectMapperTest
     {
         assertThat(() -> testWithString(INVALID_INI_5),
                 throwsException(ConfigurationException.class).withMessage(equalTo(
-                        "The property ['number'] does not contain a parsable double"))
+                        "The value defined for property ['number'] cannot be parsed as 'double'"))
                         .withCause(NumberFormatException.class));
     }
 
@@ -167,7 +167,7 @@ class INIToObjectMapperTest
     {
         assertThat(() -> testWithString(INVALID_INI_6),
                 throwsException(ConfigurationException.class).withMessage(equalTo(
-                        "The property ['section1']['section_number'] does not contain a parsable int"))
+                        "The value defined for property ['section1']['section_number'] cannot be parsed as 'int'"))
                         .withCause(NumberFormatException.class));
     }
 

--- a/confectory-core/src/test/java/net/obvj/confectory/mapper/model/MyIni.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/mapper/model/MyIni.java
@@ -1,0 +1,69 @@
+package net.obvj.confectory.mapper.model;
+
+import net.obvj.confectory.util.Property;
+
+public class MyIni
+{
+    private String rootProperty;
+    private Section section1;
+    private Section section2;
+
+    /**
+     * @return the rootProperty
+     */
+    public String getRootProperty()
+    {
+        return rootProperty;
+    }
+
+    /**
+     * @return the section1
+     */
+    public Section getSection1()
+    {
+        return section1;
+    }
+
+    /**
+     * @return the section2
+     */
+    public Section getSection2()
+    {
+        return section2;
+    }
+
+    public static class Section
+    {
+        @Property("section_string")
+        private String sectionString;
+        @Property("section_number")
+        private int sectionNumber;
+        @Property("section_bool")
+        private boolean sectionBoolean;
+
+        /**
+         * @return the sectionString
+         */
+        public String getSectionString()
+        {
+            return sectionString;
+        }
+
+        /**
+         * @return the sectionNumber
+         */
+        public int getSectionNumber()
+        {
+            return sectionNumber;
+        }
+
+        /**
+         * @return the sectionBoolean
+         */
+        public boolean isSectionBoolean()
+        {
+            return sectionBoolean;
+        }
+    }
+
+}

--- a/confectory-core/src/test/java/net/obvj/confectory/mapper/model/MyIni.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/mapper/model/MyIni.java
@@ -7,6 +7,7 @@ public class MyIni
     private String rootProperty;
     private Section section1;
     private Section section2;
+    private double number;
 
     /**
      * @return the rootProperty
@@ -32,6 +33,14 @@ public class MyIni
         return section2;
     }
 
+    /**
+     * @return the number
+     */
+    public double getNumber()
+    {
+        return number;
+    }
+
     public static class Section
     {
         @Property("section_string")
@@ -40,6 +49,8 @@ public class MyIni
         private int sectionNumber;
         @Property("section_bool")
         private boolean sectionBoolean;
+
+        private transient String transientField;
 
         /**
          * @return the sectionString
@@ -64,6 +75,15 @@ public class MyIni
         {
             return sectionBoolean;
         }
+
+        /**
+         * @return the transientField
+         */
+        public String getTransientField()
+        {
+            return transientField;
+        }
+
     }
 
 }

--- a/confectory-core/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveINIToObject.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveINIToObject.java
@@ -1,0 +1,28 @@
+package net.obvj.confectory.testdrive;
+
+import net.obvj.confectory.Configuration;
+import net.obvj.confectory.mapper.INIToObjectMapper;
+import net.obvj.confectory.testdrive.model.MyApp;
+
+public class ConfectoryTestDriveINIToObject
+{
+    public static void main(String[] args)
+    {
+        Configuration<MyApp> config = Configuration.<MyApp>builder()
+                .source("testfiles/my-app.ini")
+                .mapper(new INIToObjectMapper<MyApp>(MyApp.class))
+                .build();
+
+        MyApp app = config.getBean();
+        System.out.println(app.getTitle());
+        System.out.println(app.getOwner().getName());
+        System.out.println(app.getOwner().getOrganization());
+        System.out.println(app.getOwner().getHeight());
+        System.out.println(app.getDatabase().getServer());
+        System.out.println(app.getDatabase().getPort());
+        System.out.println(app.getDatabase().isReadOnly());
+        System.out.println(app.getDatabase().getMode());
+        System.out.println("===END===");
+
+    }
+}

--- a/confectory-core/src/test/java/net/obvj/confectory/testdrive/model/MyApp.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/testdrive/model/MyApp.java
@@ -1,0 +1,110 @@
+package net.obvj.confectory.testdrive.model;
+
+import net.obvj.confectory.util.Property;
+
+public class MyApp
+{
+    private String title;
+    private Owner owner;
+    private Database database;
+
+    /**
+     * @return the title
+     */
+    public String getTitle()
+    {
+        return title;
+    }
+
+    /**
+     * @return the owner
+     */
+    public Owner getOwner()
+    {
+        return owner;
+    }
+
+    /**
+     * @return the database
+     */
+    public Database getDatabase()
+    {
+        return database;
+    }
+
+    public static class Owner
+    {
+        private String name;
+        private String organization;
+        private double height;
+
+        /**
+         * @return the name
+         */
+        public String getName()
+        {
+            return name;
+        }
+
+        /**
+         * @return the organization
+         */
+        public String getOrganization()
+        {
+            return organization;
+        }
+
+        /**
+         * @return the height
+         */
+        public double getHeight()
+        {
+            return height;
+        }
+
+    }
+
+    public static class Database
+    {
+        private String server;
+        private int port;
+        @Property("read_only")
+        private boolean readOnly;
+        private char mode;
+
+        /**
+         * @return the server
+         */
+        public String getServer()
+        {
+            return server;
+        }
+
+        /**
+         * @return the port
+         */
+        public int getPort()
+        {
+            return port;
+        }
+
+        /**
+         * @return the readOnly
+         */
+        public boolean isReadOnly()
+        {
+            return readOnly;
+        }
+
+        /**
+         * @return the mode
+         */
+        public char getMode()
+        {
+            return mode;
+        }
+    }
+
+
+}
+

--- a/confectory-core/src/test/java/net/obvj/confectory/util/ParseFactoryTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/util/ParseFactoryTest.java
@@ -56,9 +56,15 @@ class ParseFactoryTest
     }
 
     @Test
-    void parse_string_success()
+    void parse_string_sameInstance()
     {
         assertThat(ParseFactory.parse(String.class, STR_123), sameInstance(STR_123));
+    }
+
+    @Test
+    void parse_characterEmptyString_zero()
+    {
+        assertThat(ParseFactory.parse(Character.class, ""), equalTo('\0'));
     }
 
 }

--- a/confectory-core/src/test/java/net/obvj/confectory/util/ReflectionUtilsTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/util/ReflectionUtilsTest.java
@@ -1,0 +1,22 @@
+package net.obvj.confectory.util;
+
+import static net.obvj.junit.utils.matchers.AdvancedMatchers.instantiationNotAllowed;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@link ReflectionUtils} class.
+ *
+ * @author oswaldo.bapvic.jr
+ */
+class ReflectionUtilsTest
+{
+
+    @Test
+    void constructor_instantiationNotAllowed()
+    {
+        assertThat(ReflectionUtils.class, instantiationNotAllowed().withMessage("Instantiation not allowed"));
+    }
+
+}


### PR DESCRIPTION
## New feature

### Proposed solution

Introduce a new mapper `INIToObjectMapper` for mapping INI sources as POJO inside `confectory-datamapper-core`.

### Examples of usage

#### Loading a INI file as JSONObject

##### Sample file (my.ini)

````ini
;Comment
rootProperty = myRootValue

[section1]
section_string = mySection1Value
section_number = 1

[section2]
section_string = mySection2Value
section_number = 2
````

##### Sample class

````java
public class MyIni {
    private String rootProperty;
    private MySection section1;
    private MySection section2;
    // getters omitted
    public static class MySection {
        @Property("section_string") private String string;
        @Property("section_number") private int number;
        // getters omitted
    }
}
````

##### Code sample (desired):

```` java
Configuration config = Configuration.<MyIni>builder()
                                .source(new ClasspathFileSource<>("my.ini"))
                                .mapper(new INIToObjectMapper())
                                .build();

MyIni result = config.getBean();
result.getRootProperty(); //myRootValue
result.getSection2().getNumber(); //1
result.getSection2().getNumber(); //2
````

## Quality criteria
The following criteria will be observed during the Code Review:

#### Code coverage
- The produced code shall be secured by unit tests.
- Test coverage shall remain the same or increase.

#### Documentation
- All methods shall be documented with **Javadoc**, providing examples of usage.
- Javadoc pages shall be compilable with no errors or warnings
- README.md shall be updated if applicable