### PR TITLE
New json-smart JSONObject mapper

### DIFF
--- a/confectory-core/src/main/java/net/obvj/confectory/mapper/JSONObjectMapper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/mapper/JSONObjectMapper.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.obvj.confectory.mapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+
+import net.minidev.json.JSONObject;
+import net.minidev.json.parser.JSONParser;
+import net.minidev.json.parser.ParseException;
+import net.obvj.confectory.ConfigurationException;
+import net.obvj.confectory.helper.ConfigurationHelper;
+import net.obvj.confectory.helper.JsonSmartConfigurationHelper;
+
+/**
+ * A specialized {@code Mapper} that loads the contents of a valid JSON {@code Source}
+ * (e.g.: file, URL) as a {@link JSONObject} ({@code json-smart} JSON implementation).
+ *
+ * @author oswaldo.bapvic.jr (Oswaldo Junior)
+ * @since 1.3.0
+ */
+public class JSONObjectMapper implements Mapper<JSONObject>
+{
+
+    @Override
+    public JSONObject apply(InputStream inputStream) throws IOException
+    {
+    	JSONParser parser = new JSONParser(JSONParser.DEFAULT_PERMISSIVE_MODE);
+		try
+		{
+			return parser.parse(inputStream, JSONObject.class);
+		}
+		catch (UnsupportedEncodingException | ParseException exception)
+		{
+			throw new ConfigurationException(exception);
+		}
+    }
+
+    @Override
+    public ConfigurationHelper<JSONObject> configurationHelper(JSONObject jsonObject)
+    {
+        return new JsonSmartConfigurationHelper(jsonObject);
+    }
+
+}

--- a/confectory-core/src/main/java/net/obvj/confectory/mapper/JSONObjectMapper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/mapper/JSONObjectMapper.java
@@ -32,7 +32,7 @@ import net.obvj.confectory.helper.JsonSmartConfigurationHelper;
  * (e.g.: file, URL) as a {@link JSONObject} ({@code json-smart} JSON implementation).
  *
  * @author oswaldo.bapvic.jr (Oswaldo Junior)
- * @since 1.3.0
+ * @since 2.0.0
  */
 public class JSONObjectMapper implements Mapper<JSONObject>
 {
@@ -40,15 +40,15 @@ public class JSONObjectMapper implements Mapper<JSONObject>
     @Override
     public JSONObject apply(InputStream inputStream) throws IOException
     {
-    	JSONParser parser = new JSONParser(JSONParser.DEFAULT_PERMISSIVE_MODE);
-		try
-		{
-			return parser.parse(inputStream, JSONObject.class);
-		}
-		catch (UnsupportedEncodingException | ParseException exception)
-		{
-			throw new ConfigurationException(exception);
-		}
+        JSONParser parser = new JSONParser(JSONParser.DEFAULT_PERMISSIVE_MODE);
+        try
+        {
+            return parser.parse(inputStream, JSONObject.class);
+        }
+        catch (UnsupportedEncodingException | ParseException exception)
+        {
+            throw new ConfigurationException(exception);
+        }
     }
 
     @Override

--- a/confectory-core/src/test/java/net/obvj/confectory/mapper/JSONObjectMapperTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/mapper/JSONObjectMapperTest.java
@@ -20,7 +20,7 @@ import net.obvj.confectory.helper.JsonSmartConfigurationHelper;
  * Unit tests for the {@link JSONObjectMapper} class.
  *
  * @author oswaldo.bapvic.jr
- * @since 1.3.0
+ * @since 2.0.0
  */
 class JSONObjectMapperTest
 {

--- a/confectory-core/src/test/java/net/obvj/confectory/mapper/JSONObjectMapperTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/mapper/JSONObjectMapperTest.java
@@ -1,0 +1,84 @@
+package net.obvj.confectory.mapper;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+import static net.obvj.junit.utils.matchers.AdvancedMatchers.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import net.minidev.json.parser.ParseException;
+import net.obvj.confectory.ConfigurationException;
+import net.obvj.confectory.helper.JsonSmartConfigurationHelper;
+
+/**
+ * Unit tests for the {@link JSONObjectMapper} class.
+ *
+ * @author oswaldo.bapvic.jr
+ * @since 1.3.0
+ */
+class JSONObjectMapperTest
+{
+    private static final String TEST_JSON_SAMPLE1 = "{"
+                                                  + "  \"intValue\": 9,"
+                                                  + "  \"doubleValue\": 23.98,"
+                                                  + "  \"booleanValue\": true,"
+                                                  + "  \"array\": ["
+                                                  + "    \"string1\","
+                                                  + "    \"string2\""
+                                                  + "  ]"
+                                                  + "}";
+
+    private static final String TEST_JSON_INVALID = "{";
+
+    private Mapper<JSONObject> mapper = new JSONObjectMapper();
+
+    private ByteArrayInputStream toInputStream(String content)
+    {
+        return new ByteArrayInputStream(content.getBytes());
+    }
+
+    @Test
+    void apply_validInputStream_validJSONObject() throws IOException
+    {
+        JSONObject result = mapper.apply(toInputStream(TEST_JSON_SAMPLE1));
+        assertThat(result.size(), equalTo(4));
+        assertThat(result.get("intValue"), equalTo(9));
+        assertThat(result.get("doubleValue"), equalTo(23.98));
+        assertThat(result.get("booleanValue"), equalTo(true));
+
+        JSONArray array = (JSONArray) result.get("array");
+        assertThat(array.size(), equalTo(2));
+        assertThat(array.get(0), equalTo("string1"));
+        assertThat(array.get(1), equalTo("string2"));
+    }
+
+    @Test
+    void apply_invalidJSON_configurationException() throws IOException
+    {
+        assertThat(() ->
+        {
+            try
+            {
+                mapper.apply(toInputStream(TEST_JSON_INVALID));
+            }
+            catch (IOException e)
+            {
+                fail("Expected ConfigurationException, but was IOException.");
+            }
+        }, throwsException(ConfigurationException.class).withCause(ParseException.class));
+    }
+
+    @Test
+    void configurationHelper_jsonObjectConfigurationHelper()
+    {
+        assertThat(mapper.configurationHelper(new JSONObject()).getClass(),
+                equalTo(JsonSmartConfigurationHelper.class));
+    }
+
+}

--- a/confectory-core/src/test/java/net/obvj/confectory/mapper/PropertiesMapperTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/mapper/PropertiesMapperTest.java
@@ -21,7 +21,7 @@ class PropertiesMapperTest
 {
     private static final String TEST_PROPERTIES_CONTENT = "web.host=localhost\nweb.port=1910";
 
-    private PropertiesMapper mapper = new PropertiesMapper();
+    private Mapper<Properties> mapper = new PropertiesMapper();
 
     @Test
     void apply_validInputStream_loadedSuccessfully() throws IOException

--- a/confectory-core/src/test/java/net/obvj/confectory/mapper/StringMapperTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/mapper/StringMapperTest.java
@@ -20,7 +20,7 @@ class StringMapperTest
 {
     private static final String TEST_CONTENT = "content";
 
-    private StringMapper mapper = new StringMapper();
+    private Mapper<String> mapper = new StringMapper();
 
     @Test
     void apply_validInputStream_loadedSuccessfully() throws IOException

--- a/confectory-datamapper-json-org/src/main/java/net/obvj/confectory/helper/JsonOrgJSONObjectHelper.java
+++ b/confectory-datamapper-json-org/src/main/java/net/obvj/confectory/helper/JsonOrgJSONObjectHelper.java
@@ -28,7 +28,7 @@ import com.jayway.jsonpath.spi.mapper.JsonOrgMappingProvider;
  * {@link JSONObject}, with JSONPath capabilities.
  *
  * @author oswaldo.bapvic.jr (Oswaldo Junior)
- * @since 0.2.0
+ * @since 2.0.0 (<b>note:</b> since 0.2.0 as {@code JSONObjectConfigurationHelperMapper})
  */
 public class JsonOrgJSONObjectHelper extends GenericJsonConfigurationHelper<JSONObject>
 {

--- a/confectory-datamapper-json-org/src/main/java/net/obvj/confectory/helper/JsonOrgJSONObjectHelper.java
+++ b/confectory-datamapper-json-org/src/main/java/net/obvj/confectory/helper/JsonOrgJSONObjectHelper.java
@@ -30,7 +30,7 @@ import com.jayway.jsonpath.spi.mapper.JsonOrgMappingProvider;
  * @author oswaldo.bapvic.jr (Oswaldo Junior)
  * @since 0.2.0
  */
-public class JSONObjectHelper extends GenericJsonConfigurationHelper<JSONObject>
+public class JsonOrgJSONObjectHelper extends GenericJsonConfigurationHelper<JSONObject>
 {
 
     /**
@@ -38,7 +38,7 @@ public class JSONObjectHelper extends GenericJsonConfigurationHelper<JSONObject>
      *
      * @param jsonObject the JSON object to be set
      */
-    public JSONObjectHelper(JSONObject jsonObject)
+    public JsonOrgJSONObjectHelper(JSONObject jsonObject)
     {
         super(jsonObject, new JsonOrgJsonProvider(), new JsonOrgMappingProvider());
     }

--- a/confectory-datamapper-json-org/src/main/java/net/obvj/confectory/mapper/JsonOrgJSONObjectMapper.java
+++ b/confectory-datamapper-json-org/src/main/java/net/obvj/confectory/mapper/JsonOrgJSONObjectMapper.java
@@ -18,27 +18,34 @@ package net.obvj.confectory.mapper;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Properties;
 
 import org.json.JSONObject;
-import org.json.Property;
+import org.json.JSONTokener;
+
+import net.obvj.confectory.helper.ConfigurationHelper;
+import net.obvj.confectory.helper.JsonOrgJSONObjectHelper;
 
 /**
- * A specialized {@code Mapper} that loads the contents of a {@code Source} (e.g.: file,
- * URL) in the {@code Properties} format (a sequence of key-value pairs) and converts it
- * into a {@link JSONObject} ({@code json.org} reference implementation).
+ * A specialized {@code Mapper} that loads the contents of a valid JSON {@code Source}
+ * (e.g.: file, URL) as a {@link JSONObject} ({@code json.org} reference implementation).
  *
  * @author oswaldo.bapvic.jr (Oswaldo Junior)
  * @since 0.2.0
  */
-public class PropertiesToJSONObjectMapper extends JSONObjectMapper implements Mapper<JSONObject>
+public class JsonOrgJSONObjectMapper implements Mapper<JSONObject>
 {
 
     @Override
     public JSONObject apply(InputStream inputStream) throws IOException
     {
-        Properties properties = new PropertiesMapper().apply(inputStream);
-        return Property.toJSONObject(properties);
+        JSONTokener tokener = new JSONTokener(inputStream);
+        return new JSONObject(tokener);
+    }
+
+    @Override
+    public ConfigurationHelper<JSONObject> configurationHelper(JSONObject jsonObject)
+    {
+        return new JsonOrgJSONObjectHelper(jsonObject);
     }
 
 }

--- a/confectory-datamapper-json-org/src/main/java/net/obvj/confectory/mapper/JsonOrgJSONObjectMapper.java
+++ b/confectory-datamapper-json-org/src/main/java/net/obvj/confectory/mapper/JsonOrgJSONObjectMapper.java
@@ -30,7 +30,7 @@ import net.obvj.confectory.helper.JsonOrgJSONObjectHelper;
  * (e.g.: file, URL) as a {@link JSONObject} ({@code json.org} reference implementation).
  *
  * @author oswaldo.bapvic.jr (Oswaldo Junior)
- * @since 0.2.0
+ * @since 2.0.0 (<b>note:</b> since 0.2.0 as {@code JSONObjectMapper})
  */
 public class JsonOrgJSONObjectMapper implements Mapper<JSONObject>
 {

--- a/confectory-datamapper-json-org/src/main/java/net/obvj/confectory/mapper/JsonOrgPropertiesToJSONObjectMapper.java
+++ b/confectory-datamapper-json-org/src/main/java/net/obvj/confectory/mapper/JsonOrgPropertiesToJSONObjectMapper.java
@@ -29,7 +29,7 @@ import org.json.Property;
  * into a {@link JSONObject} ({@code json.org} reference implementation).
  *
  * @author oswaldo.bapvic.jr (Oswaldo Junior)
- * @since 0.2.0
+ * @since 2.0.0 (<b>note:</b> since 0.2.0 as {@code PropertiesToJSONObjectMapper})
  */
 public class JsonOrgPropertiesToJSONObjectMapper extends JsonOrgJSONObjectMapper implements Mapper<JSONObject>
 {

--- a/confectory-datamapper-json-org/src/main/java/net/obvj/confectory/mapper/JsonOrgPropertiesToJSONObjectMapper.java
+++ b/confectory-datamapper-json-org/src/main/java/net/obvj/confectory/mapper/JsonOrgPropertiesToJSONObjectMapper.java
@@ -18,34 +18,27 @@ package net.obvj.confectory.mapper;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Properties;
 
 import org.json.JSONObject;
-import org.json.JSONTokener;
-
-import net.obvj.confectory.helper.ConfigurationHelper;
-import net.obvj.confectory.helper.JSONObjectHelper;
+import org.json.Property;
 
 /**
- * A specialized {@code Mapper} that loads the contents of a valid JSON {@code Source}
- * (e.g.: file, URL) as a {@link JSONObject} ({@code json.org} reference implementation).
+ * A specialized {@code Mapper} that loads the contents of a {@code Source} (e.g.: file,
+ * URL) in the {@code Properties} format (a sequence of key-value pairs) and converts it
+ * into a {@link JSONObject} ({@code json.org} reference implementation).
  *
  * @author oswaldo.bapvic.jr (Oswaldo Junior)
  * @since 0.2.0
  */
-public class JSONObjectMapper implements Mapper<JSONObject>
+public class JsonOrgPropertiesToJSONObjectMapper extends JsonOrgJSONObjectMapper implements Mapper<JSONObject>
 {
 
     @Override
     public JSONObject apply(InputStream inputStream) throws IOException
     {
-        JSONTokener tokener = new JSONTokener(inputStream);
-        return new JSONObject(tokener);
-    }
-
-    @Override
-    public ConfigurationHelper<JSONObject> configurationHelper(JSONObject jsonObject)
-    {
-        return new JSONObjectHelper(jsonObject);
+        Properties properties = new PropertiesMapper().apply(inputStream);
+        return Property.toJSONObject(properties);
     }
 
 }

--- a/confectory-datamapper-json-org/src/main/java/net/obvj/confectory/mapper/JsonOrgXMLToJSONObjectMapper.java
+++ b/confectory-datamapper-json-org/src/main/java/net/obvj/confectory/mapper/JsonOrgXMLToJSONObjectMapper.java
@@ -46,7 +46,7 @@ import org.json.XML;
  * @author oswaldo.bapvic.jr (Oswaldo Junior)
  * @since 0.2.0
  */
-public class XMLToJSONObjectMapper extends JSONObjectMapper implements Mapper<JSONObject>
+public class JsonOrgXMLToJSONObjectMapper extends JsonOrgJSONObjectMapper implements Mapper<JSONObject>
 {
 
     @Override

--- a/confectory-datamapper-json-org/src/main/java/net/obvj/confectory/mapper/JsonOrgXMLToJSONObjectMapper.java
+++ b/confectory-datamapper-json-org/src/main/java/net/obvj/confectory/mapper/JsonOrgXMLToJSONObjectMapper.java
@@ -44,7 +44,7 @@ import org.json.XML;
  * {@link Mapper} implementation.
  *
  * @author oswaldo.bapvic.jr (Oswaldo Junior)
- * @since 0.2.0
+ * @since 2.0.0 (<b>note:</b> since 0.2.0 as {@code XMLTOJSONObjectMapper})
  */
 public class JsonOrgXMLToJSONObjectMapper extends JsonOrgJSONObjectMapper implements Mapper<JSONObject>
 {

--- a/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/helper/JsonOrgJSONObjectHelperTest.java
+++ b/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/helper/JsonOrgJSONObjectHelperTest.java
@@ -14,13 +14,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import net.obvj.confectory.ConfigurationException;
 
 /**
- * Unit tests for the {@link JSONObjectHelper}.
+ * Unit tests for the {@link JsonOrgJSONObjectHelper}.
  *
  * @author oswaldo.bapvic.jr (Oswaldo Junior)
  * @since 0.2.0
  */
 @ExtendWith(MockitoExtension.class)
-class JSONObjectHelperTest
+class JsonOrgJSONObjectHelperTest
 {
     private static final String PATH_UNKNOWN = "$.unknown";
 
@@ -48,7 +48,7 @@ class JSONObjectHelperTest
             + "  }\r\n"
             + "}");
 
-    private static final JSONObjectHelper HELPER = new JSONObjectHelper(TEST_JSON_SAMPLE1);
+    private static final JsonOrgJSONObjectHelper HELPER = new JsonOrgJSONObjectHelper(TEST_JSON_SAMPLE1);
 
 
     @Test

--- a/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/helper/JsonOrgJSONObjectHelperTest.java
+++ b/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/helper/JsonOrgJSONObjectHelperTest.java
@@ -48,7 +48,8 @@ class JsonOrgJSONObjectHelperTest
             + "  }\r\n"
             + "}");
 
-    private static final JsonOrgJSONObjectHelper HELPER = new JsonOrgJSONObjectHelper(TEST_JSON_SAMPLE1);
+    private static final ConfigurationHelper<JSONObject> HELPER = new JsonOrgJSONObjectHelper(
+            TEST_JSON_SAMPLE1);
 
 
     @Test

--- a/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/mapper/JsonOrgJSONObjectMapperTest.java
+++ b/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/mapper/JsonOrgJSONObjectMapperTest.java
@@ -10,15 +10,15 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
-import net.obvj.confectory.helper.JSONObjectHelper;
+import net.obvj.confectory.helper.JsonOrgJSONObjectHelper;
 
 /**
- * Unit tests for the {@link JSONObjectMapper} class.
+ * Unit tests for the {@link JsonOrgJSONObjectMapper} class.
  *
  * @author oswaldo.bapvic.jr
  * @since 0.2.0
  */
-class JSONObjectMapperTest
+class JsonOrgJSONObjectMapperTest
 {
     private static final String TEST_JSON_SAMPLE1 = "{"
                                                   + "  \"intValue\": 9,"
@@ -29,7 +29,7 @@ class JSONObjectMapperTest
                                                   + "  ]"
                                                   + "}";
 
-    private JSONObjectMapper mapper = new JSONObjectMapper();
+    private JsonOrgJSONObjectMapper mapper = new JsonOrgJSONObjectMapper();
 
     private ByteArrayInputStream toInputStream(String content)
     {
@@ -53,7 +53,7 @@ class JSONObjectMapperTest
     @Test
     void configurationHelper_jsonObjectConfigurationHelper()
     {
-        assertThat(mapper.configurationHelper(new JSONObject()).getClass(), equalTo(JSONObjectHelper.class));
+        assertThat(mapper.configurationHelper(new JSONObject()).getClass(), equalTo(JsonOrgJSONObjectHelper.class));
     }
 
 }

--- a/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/mapper/JsonOrgJSONObjectMapperTest.java
+++ b/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/mapper/JsonOrgJSONObjectMapperTest.java
@@ -29,7 +29,7 @@ class JsonOrgJSONObjectMapperTest
                                                   + "  ]"
                                                   + "}";
 
-    private JsonOrgJSONObjectMapper mapper = new JsonOrgJSONObjectMapper();
+    private Mapper<JSONObject> mapper = new JsonOrgJSONObjectMapper();
 
     private ByteArrayInputStream toInputStream(String content)
     {

--- a/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/mapper/JsonOrgPropertiesToJSONObjectMapperTest.java
+++ b/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/mapper/JsonOrgPropertiesToJSONObjectMapperTest.java
@@ -9,15 +9,15 @@ import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
-import net.obvj.confectory.helper.JSONObjectHelper;
+import net.obvj.confectory.helper.JsonOrgJSONObjectHelper;
 
 /**
- * Unit tests for the {@link PropertiesToJSONObjectMapper} class.
+ * Unit tests for the {@link JsonOrgPropertiesToJSONObjectMapper} class.
  *
  * @author oswaldo.bapvic.jr (Oswaldo Junior)
  * @since 0.2.0
  */
-class PropertiesToJSONObjectMapperTest
+class JsonOrgPropertiesToJSONObjectMapperTest
 {
     private static final String TEST_PROPERTIES_SAMPLE1
             = "intValue=9\n"
@@ -25,7 +25,7 @@ class PropertiesToJSONObjectMapperTest
             + "stringValue=string1\n";
 
 
-    private PropertiesToJSONObjectMapper mapper = new PropertiesToJSONObjectMapper();
+    private JsonOrgPropertiesToJSONObjectMapper mapper = new JsonOrgPropertiesToJSONObjectMapper();
 
     private ByteArrayInputStream toInputStream(String content)
     {
@@ -45,7 +45,7 @@ class PropertiesToJSONObjectMapperTest
     @Test
     void configurationHelper_jsonObjectConfigurationHelper()
     {
-        assertThat(mapper.configurationHelper(new JSONObject()).getClass(), equalTo(JSONObjectHelper.class));
+        assertThat(mapper.configurationHelper(new JSONObject()).getClass(), equalTo(JsonOrgJSONObjectHelper.class));
     }
 
 }

--- a/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/mapper/JsonOrgPropertiesToJSONObjectMapperTest.java
+++ b/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/mapper/JsonOrgPropertiesToJSONObjectMapperTest.java
@@ -25,7 +25,7 @@ class JsonOrgPropertiesToJSONObjectMapperTest
             + "stringValue=string1\n";
 
 
-    private JsonOrgPropertiesToJSONObjectMapper mapper = new JsonOrgPropertiesToJSONObjectMapper();
+    private Mapper<JSONObject> mapper = new JsonOrgPropertiesToJSONObjectMapper();
 
     private ByteArrayInputStream toInputStream(String content)
     {

--- a/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/mapper/JsonOrgXMLToJSONObjectMapperTest.java
+++ b/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/mapper/JsonOrgXMLToJSONObjectMapperTest.java
@@ -31,7 +31,7 @@ class JsonOrgXMLToJSONObjectMapperTest
             + "</root>\n";
 
 
-    private JsonOrgXMLToJSONObjectMapper mapper = new JsonOrgXMLToJSONObjectMapper();
+    private Mapper<JSONObject> mapper = new JsonOrgXMLToJSONObjectMapper();
 
     private ByteArrayInputStream toInputStream(String content)
     {

--- a/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/mapper/JsonOrgXMLToJSONObjectMapperTest.java
+++ b/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/mapper/JsonOrgXMLToJSONObjectMapperTest.java
@@ -10,15 +10,15 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
-import net.obvj.confectory.helper.JSONObjectHelper;
+import net.obvj.confectory.helper.JsonOrgJSONObjectHelper;
 
 /**
- * Unit tests for the {@link XMLToJSONObjectMapper} class.
+ * Unit tests for the {@link JsonOrgXMLToJSONObjectMapper} class.
  *
  * @author oswaldo.bapvic.jr (Oswaldo Junior)
  * @since 0.2.0
  */
-class XMLToJSONObjectMapperTest
+class JsonOrgXMLToJSONObjectMapperTest
 {
     private static final String TEST_XML_SAMPLE1
             = "<root>\n"
@@ -31,7 +31,7 @@ class XMLToJSONObjectMapperTest
             + "</root>\n";
 
 
-    private XMLToJSONObjectMapper mapper = new XMLToJSONObjectMapper();
+    private JsonOrgXMLToJSONObjectMapper mapper = new JsonOrgXMLToJSONObjectMapper();
 
     private ByteArrayInputStream toInputStream(String content)
     {
@@ -56,7 +56,7 @@ class XMLToJSONObjectMapperTest
     @Test
     void configurationHelper_jsonObjectConfigurationHelper()
     {
-        assertThat(mapper.configurationHelper(new JSONObject()).getClass(), equalTo(JSONObjectHelper.class));
+        assertThat(mapper.configurationHelper(new JSONObject()).getClass(), equalTo(JsonOrgJSONObjectHelper.class));
     }
 
 }

--- a/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveURLToJSONObject.java
+++ b/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveURLToJSONObject.java
@@ -4,7 +4,7 @@ package net.obvj.confectory.testdrive;
 import org.json.JSONObject;
 
 import net.obvj.confectory.Configuration;
-import net.obvj.confectory.mapper.JSONObjectMapper;
+import net.obvj.confectory.mapper.JsonOrgJSONObjectMapper;
 
 public class ConfectoryTestDriveURLToJSONObject
 {
@@ -13,7 +13,7 @@ public class ConfectoryTestDriveURLToJSONObject
         Configuration<JSONObject> config = Configuration.<JSONObject>builder()
                 .namespace("test")
                 .source("http://ip.jsontest.com")
-                .mapper(new JSONObjectMapper())
+                .mapper(new JsonOrgJSONObjectMapper())
                 .build();
 
         System.out.println(config.getBean().toString(2));

--- a/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveXMLToJSONObject.java
+++ b/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveXMLToJSONObject.java
@@ -3,7 +3,7 @@ package net.obvj.confectory.testdrive;
 import org.json.JSONObject;
 
 import net.obvj.confectory.Configuration;
-import net.obvj.confectory.mapper.XMLToJSONObjectMapper;
+import net.obvj.confectory.mapper.JsonOrgXMLToJSONObjectMapper;
 
 public class ConfectoryTestDriveXMLToJSONObject
 {
@@ -12,7 +12,7 @@ public class ConfectoryTestDriveXMLToJSONObject
         Configuration<JSONObject> config = Configuration.<JSONObject>builder()
                 .namespace("test")
                 .source("testfiles/agents.xml")
-                .mapper(new XMLToJSONObjectMapper()).build();
+                .mapper(new JsonOrgXMLToJSONObjectMapper()).build();
 
         System.out.println(config.getBean().toString(2));
         System.out.println(config.getBoolean("conf.enabled"));

--- a/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveXMLToJSONObject2.java
+++ b/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveXMLToJSONObject2.java
@@ -3,7 +3,7 @@ package net.obvj.confectory.testdrive;
 import org.json.JSONObject;
 
 import net.obvj.confectory.Configuration;
-import net.obvj.confectory.mapper.XMLToJSONObjectMapper;
+import net.obvj.confectory.mapper.JsonOrgXMLToJSONObjectMapper;
 import net.obvj.confectory.source.SourceFactory;
 
 public class ConfectoryTestDriveXMLToJSONObject2
@@ -15,7 +15,7 @@ public class ConfectoryTestDriveXMLToJSONObject2
         Configuration<JSONObject> config = Configuration.<JSONObject>builder()
                 .namespace("test")
                 .source(SourceFactory.stringSource(xml))
-                .mapper(new XMLToJSONObjectMapper())
+                .mapper(new JsonOrgXMLToJSONObjectMapper())
                 .build();
 
         System.out.println(config.getBean().toString(2));

--- a/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveXMLToJSONObjectMultiThread.java
+++ b/confectory-datamapper-json-org/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveXMLToJSONObjectMultiThread.java
@@ -10,7 +10,7 @@ import org.apache.commons.io.FileUtils;
 import org.json.JSONObject;
 
 import net.obvj.confectory.Configuration;
-import net.obvj.confectory.mapper.XMLToJSONObjectMapper;
+import net.obvj.confectory.mapper.JsonOrgXMLToJSONObjectMapper;
 
 public class ConfectoryTestDriveXMLToJSONObjectMultiThread
 {
@@ -25,7 +25,7 @@ public class ConfectoryTestDriveXMLToJSONObjectMultiThread
 
         Configuration<JSONObject> config = Configuration.<JSONObject>builder()
                 .source("testfiles/agents.xml")
-                .mapper(new XMLToJSONObjectMapper()).build();
+                .mapper(new JsonOrgXMLToJSONObjectMapper()).build();
 
         Runnable runnable = () ->
         {


### PR DESCRIPTION
## New feature

### Proposed solution

1. Introduce a new mapper `JSONObjectMapper` for mapping JSON as json-smart's JSONObject inside `confectory-core`.

2. Let json-smart be the preferred provider for JSON.

3. Rename the existing `JSONObjectMapper` to `JsonOrgJSONObjectMapper`.

## Quality criteria
The following criteria will be observed during the Code Review:

#### Code coverage
- The produced code shall be secured by unit tests.
- Test coverage shall remain the same or increase.

#### Documentation
- All methods shall be documented with **Javadoc**, providing examples of usage.
- Javadoc pages shall be compilable with no errors or warnings
- README.md shall be updated if applicable