### PR TITLE
Set DataFetchStrategy.LENIENT as default

### DIFF
--- a/confectory-core/src/main/java/net/obvj/confectory/ConfigurationContainer.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/ConfigurationContainer.java
@@ -90,10 +90,12 @@ public class ConfigurationContainer
      * an arbitrary number of preset {@code Configuration} objects.
      *
      * @param dataFetchStrategy an optional {@link DataFetchStrategy} to be applied by this
-     *                          container; {@code null} is allowed and means the default
-     *                          strategy will be applied
+     *                          container; {@code null} is allowed and indicates that the
+     *                          default strategy defined in {@link Confectory#settings()} will
+     *                          be applied
      * @param configs           an arbitrary number of {@code Configuration} objects (zero or
      *                          more) to be registered at constructor time
+     * @see ConfectorySettings
      */
     public ConfigurationContainer(DataFetchStrategy dataFetchStrategy, Configuration<?>... configs)
     {

--- a/confectory-core/src/main/java/net/obvj/confectory/DataFetchStrategy.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/DataFetchStrategy.java
@@ -39,55 +39,63 @@ import net.obvj.confectory.util.ConfigurationComparator;
 public enum DataFetchStrategy
 {
     /**
-     * Retrieves <b>sorted</b> data from {@code Configuration} objects declared
-     * with a specific namespace.
+     * Retrieves <b>sorted</b> data from {@code Configuration} objects declared with a
+     * specific namespace.
      * <p>
-     * If no namespace is specified during data fetch, only {@link Configuration}
-     * objects <b>without a namespace defined</b> will be searched.
+     * If no namespace is specified during data fetch, only {@link Configuration} objects
+     * <b>without a namespace defined</b> will be searched.
+     * <p>
+     * {@code Configuration} objects are sorted from the highest to the lowest precedence
+     * attribute, as determined by the {@link ConfigurationComparator}.
      */
     STRICT
     {
         @Override
-        protected Stream<Configuration<?>> getConfigurationStream(String namespace,
+        Stream<Configuration<?>> getConfigurationStream(String namespace,
                 Map<String, Set<Configuration<?>>> configMap)
         {
-            return STRICT_UNSORTED.getConfigurationStream(namespace, configMap).sorted(new ConfigurationComparator());
+            return STRICT_UNSORTED.getConfigurationStream(namespace, configMap)
+                    .sorted(new ConfigurationComparator());
         }
     },
 
     /**
-     * Retrieves <b>unsorted</b> data from {@code Configuration} objects declared
-     * with a specific namespace.
+     * Retrieves <b>unsorted</b> data from {@code Configuration} objects declared with a
+     * specific namespace.
      * <p>
-     * If no namespace is specified during data fetch, only {@link Configuration}
-     * objects <b>without a namespace defined</b> will be searched.
+     * If no namespace is specified during data fetch, only {@link Configuration} objects
+     * <b>without a namespace defined</b> will be searched.
      *
      * @since 0.2.0
      */
     STRICT_UNSORTED
     {
         @Override
-        protected Stream<Configuration<?>> getConfigurationStream(String namespace,
-                Map<String, Set<Configuration<?>>> configMap) {
-            return configMap.getOrDefault(parseNamespace(namespace), Collections.emptySet()).stream();
+        Stream<Configuration<?>> getConfigurationStream(String namespace,
+                Map<String, Set<Configuration<?>>> configMap)
+        {
+            return configMap.getOrDefault(parseNamespace(namespace), Collections.emptySet())
+                    .stream();
         }
     },
 
     /**
-     * Retrieves <b>sorted</b> data from all {@code Configuration} objects
-     * regardless of their namespaces <b>when no namespace specified</b> during data
-     * fetch.
+     * Retrieves <b>sorted</b> data from all {@code Configuration} objects regardless of their
+     * namespaces <b>when no namespace specified</b> during data fetch.
+     * <p>
+     * {@code Configuration} objects are sorted from the highest to the lowest precedence
+     * attribute, as determined by the {@link ConfigurationComparator}.
      */
     LENIENT
     {
         @Override
-        protected Stream<Configuration<?>> getConfigurationStream(String namespace,
+        Stream<Configuration<?>> getConfigurationStream(String namespace,
                 Map<String, Set<Configuration<?>>> configMap)
         {
             if (StringUtils.isEmpty(namespace))
             {
                 // Flatten and re-order the configuration list
-                return  LENIENT_UNSORTED.getConfigurationStream(namespace, configMap)
+                return LENIENT_UNSORTED.getConfigurationStream(namespace, configMap)
                         .sorted(new ConfigurationComparator());
             }
             return STRICT.getConfigurationStream(namespace, configMap);
@@ -95,16 +103,15 @@ public enum DataFetchStrategy
     },
 
     /**
-     * Retrieves <b>unsorted</b> data from all {@code Configuration} objects
-     * regardless of their namespaces <b>when no namespace specified</b> during data
-     * fetch.
+     * Retrieves <b>unsorted</b> data from all {@code Configuration} objects regardless of
+     * their namespaces <b>when no namespace specified</b> during data fetch.
      *
      * @since 0.2.0
      */
     LENIENT_UNSORTED
     {
         @Override
-        protected Stream<Configuration<?>> getConfigurationStream(String namespace,
+        Stream<Configuration<?>> getConfigurationStream(String namespace,
                 Map<String, Set<Configuration<?>>> configMap)
         {
             if (StringUtils.isEmpty(namespace))
@@ -123,14 +130,14 @@ public enum DataFetchStrategy
      * Retrieves a stream of sorted {@link Configuration} objects based on the specified
      * {@code namespace}.
      * <p>
-     * The {@link Configuration} objects may be sorted by precedence (highest to lowest).
+     * The {@link Configuration} objects will be sorted by precedence (highest to lowest).
      *
      * @param namespace the namespace to be searched
      * @param configMap the source map
      * @return a stream of {@link Configuration} objects according to the selected strategy,
      *         never {@code null}
      */
-    protected abstract Stream<Configuration<?>> getConfigurationStream(String namespace,
+    abstract Stream<Configuration<?>> getConfigurationStream(String namespace,
             Map<String, Set<Configuration<?>>> configMap);
 
     /**

--- a/confectory-core/src/main/java/net/obvj/confectory/DataFetchStrategy.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/DataFetchStrategy.java
@@ -125,12 +125,9 @@ public enum DataFetchStrategy
     };
 
 
-
     /**
      * Retrieves a stream of sorted {@link Configuration} objects based on the specified
      * {@code namespace}.
-     * <p>
-     * The {@link Configuration} objects will be sorted by precedence (highest to lowest).
      *
      * @param namespace the namespace to be searched
      * @param configMap the source map
@@ -142,7 +139,7 @@ public enum DataFetchStrategy
 
     /**
      * Returns either the passed namespace, or a default value, if the passed argument is
-     * empty or null
+     * empty or null.
      *
      * @param namespace the namespace to the checked
      * @return the passed namespace, or the value of

--- a/confectory-core/src/main/java/net/obvj/confectory/TypeSafeConfigurationContainer.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/TypeSafeConfigurationContainer.java
@@ -73,6 +73,7 @@ public final class TypeSafeConfigurationContainer<T>
      * @since 2.4.0
      * @see ConfectorySettings
      */
+    @SafeVarargs
     public TypeSafeConfigurationContainer(DataFetchStrategy dataFetchStrategy, Configuration<?>... configs)
     {
         container = new ConfigurationContainer(dataFetchStrategy, configs);

--- a/confectory-core/src/main/java/net/obvj/confectory/TypeSafeConfigurationContainer.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/TypeSafeConfigurationContainer.java
@@ -16,16 +16,18 @@
 
 package net.obvj.confectory;
 
+import net.obvj.confectory.settings.ConfectorySettings;
+
 /**
  * An object that holds multiple {@code Configuration} objects of the same generic type
- * {@code <T>} and selects the highest-precedence available ones. This is particularly
- * useful for source prioritization or handling multiple versions of the same
- * configuration object.
+ * {@code <T>} and selects the highest-precedence available ones when {@code getBean()} is
+ * called. This is particularly useful for source prioritization or handling multiple
+ * versions of the same configuration bean.
  * <p>
  * To create a new empty container, use the default constructor
  * {@code new TypeSafeConfigurationContainer<T>()}. To create a new container with preset
- * {@code Configuration} objects, pass them as "var-args", provided that all objects have
- * the same mapped bean type {@code <T>}
+ * {@code Configuration<T>} objects, pass them as "var-args", provided that all objects
+ * have the same mapped bean type {@code <T>}
  * <p>
  * Use the {@code add(Configuration<T>)} method at any time to register new objects inside
  * the container.
@@ -45,7 +47,7 @@ public final class TypeSafeConfigurationContainer<T>
     private ConfigurationContainer container;
 
     /**
-     * Builds a new {@code TypeSageConfigurationContainer} with an arbitrary number of preset
+     * Builds a new {@code TypeSafeConfigurationContainer} with an arbitrary number of preset
      * {@code Configuration} objects to be registered.
      *
      * @param configs an arbitrary number of {@code Configuration} objects (zero or more) to
@@ -54,7 +56,26 @@ public final class TypeSafeConfigurationContainer<T>
     @SafeVarargs
     public TypeSafeConfigurationContainer(Configuration<T>... configs)
     {
-        container = new ConfigurationContainer(DataFetchStrategy.STRICT, configs);
+        this(null, configs);
+    }
+
+    /**
+     * Builds a new {@code TypeSageConfigurationContainer} with a custom
+     * {@link DataFetchStrategy} and an arbitrary number of preset {@code Configuration}
+     * objects.
+     *
+     * @param dataFetchStrategy an optional {@link DataFetchStrategy} to be applied by this
+     *                          container; {@code null} is allowed and indicates that the
+     *                          default strategy defined in {@link Confectory#settings()} will
+     *                          be applied
+     * @param configs           an arbitrary number of {@code Configuration} objects (zero or
+     *                          more) to be registered at constructor time
+     * @since 2.4.0
+     * @see ConfectorySettings
+     */
+    public TypeSafeConfigurationContainer(DataFetchStrategy dataFetchStrategy, Configuration<?>... configs)
+    {
+        container = new ConfigurationContainer(dataFetchStrategy, configs);
     }
 
     /**
@@ -138,7 +159,7 @@ public final class TypeSafeConfigurationContainer<T>
      * @return the internal {@link ConfigurationContainer}, mainly for testing or
      *         troubleshooting purposes
      */
-    protected ConfigurationContainer getInternal()
+    ConfigurationContainer getInternal()
     {
         return container;
     }

--- a/confectory-core/src/main/java/net/obvj/confectory/settings/ConfectorySettings.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/settings/ConfectorySettings.java
@@ -30,9 +30,9 @@ public class ConfectorySettings
 {
 
     /**
-     * The initial {@link DataFetchStrategy} to be applied by default
+     * The initial {@link DataFetchStrategy} applied by default
      */
-    protected static final DataFetchStrategy INITIAL_DATA_FETCH_STRATEGY = DataFetchStrategy.STRICT;
+    static final DataFetchStrategy INITIAL_DATA_FETCH_STRATEGY = DataFetchStrategy.LENIENT;
 
     private static final ConfectorySettings INSTANCE = new ConfectorySettings();
 

--- a/confectory-core/src/test/java/net/obvj/confectory/ConfigurationContainerTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/ConfigurationContainerTest.java
@@ -147,7 +147,7 @@ class ConfigurationContainerTest
     @Test
     void getString_keyOnlyAndStrict_configurationWithoutNamespace()
     {
-        container = new ConfigurationContainer(CONF_NS1_PROPERTIES_1, CONF_NS2_PROPERTIES_1, CONF_PROPERTIES_1);
+        container = new ConfigurationContainer(DataFetchStrategy.STRICT, CONF_NS1_PROPERTIES_1, CONF_NS2_PROPERTIES_1, CONF_PROPERTIES_1);
         assertThat(container.getString(KEY_TEST), equalTo("ok01")); // CONF_PROPERTIES1 (strict)
         assertThat(container.getString(KEY_STRING), equalTo(null)); // not found (strict)
     }
@@ -155,7 +155,7 @@ class ConfigurationContainerTest
     @Test
     void getString_keyOnlyAndLenient_configurationWithoutNamespace()
     {
-        container = new ConfigurationContainer(DataFetchStrategy.LENIENT, CONF_NS1_PROPERTIES_1, CONF_NS1_PROPERTIES_2, CONF_NS2_PROPERTIES_1, CONF_PROPERTIES_1);
+        container = new ConfigurationContainer(CONF_NS1_PROPERTIES_1, CONF_NS1_PROPERTIES_2, CONF_NS2_PROPERTIES_1, CONF_PROPERTIES_1);
         assertThat(container.getString(KEY_TEST), equalTo("ok21")); // CONF_NS2_PROPERTIES_1 (lenient)
         assertThat(container.getString(KEY_STRING), equalTo("string2")); // CONF_NS1_PROPERTIES_2 (lenient)
     }
@@ -199,9 +199,16 @@ class ConfigurationContainerTest
     }
 
     @Test
-    void getInteger_keyOnly_configurationWithoutNamespace()
+    void getInteger_keyOnlyAndLenient_configurationWithoutNamespace()
     {
         container = new ConfigurationContainer(CONF_NS1_PROPERTIES_1, CONF_NS2_PROPERTIES_1, CONF_PROPERTIES_1);
+        assertThat(container.getInteger(KEY_INT), equalTo(1)); // CONF_NS1_PROPERTIES_1
+    }
+
+    @Test
+    void getInteger_keyOnlyAndStrict_configurationWithoutNamespace()
+    {
+        container = new ConfigurationContainer(DataFetchStrategy.STRICT, CONF_NS1_PROPERTIES_1, CONF_NS2_PROPERTIES_1, CONF_PROPERTIES_1);
         assertThat(container.getInteger(KEY_INT), equalTo(10)); // CONF_PROPERTIES1
     }
 
@@ -220,9 +227,16 @@ class ConfigurationContainerTest
     }
 
     @Test
-    void getBoolean_keyOnly_configurationWithoutNamespace()
+    void getBoolean_keyOnlyAndLenient_configurationWithoutNamespace()
     {
         container = new ConfigurationContainer(CONF_NS1_PROPERTIES_1, CONF_NS2_PROPERTIES_1, CONF_PROPERTIES_1);
+        assertThat(container.getBoolean(KEY_BOOLEAN), equalTo(false)); // CONF_NS1_PROPERTIES_1
+    }
+
+    @Test
+    void getBoolean_keyOnlyAndStrict_configurationWithoutNamespace()
+    {
+        container = new ConfigurationContainer(DataFetchStrategy.STRICT, CONF_NS1_PROPERTIES_1, CONF_NS2_PROPERTIES_1, CONF_PROPERTIES_1);
         assertThat(container.getBoolean(KEY_BOOLEAN), equalTo(true)); // CONF_PROPERTIES1
     }
 
@@ -241,9 +255,16 @@ class ConfigurationContainerTest
     }
 
     @Test
-    void getDouble_keyOnly_configurationWithoutNamespace()
+    void getDouble_keyOnlyAndLenient_configurationWithoutNamespace()
     {
         container = new ConfigurationContainer(CONF_NS1_PROPERTIES_1, CONF_NS2_PROPERTIES_1, CONF_PROPERTIES_1);
+        assertThat(container.getDouble(KEY_DOUBLE), equalTo(10.1)); // CONF_PROPERTIES1
+    }
+
+    @Test
+    void getDouble_keyOnlyAndString_configurationWithoutNamespace()
+    {
+        container = new ConfigurationContainer(DataFetchStrategy.STRICT, CONF_NS1_PROPERTIES_1, CONF_NS2_PROPERTIES_1, CONF_PROPERTIES_1);
         assertThat(container.getDouble(KEY_DOUBLE), equalTo(10.1)); // CONF_PROPERTIES1
     }
 
@@ -262,9 +283,16 @@ class ConfigurationContainerTest
     }
 
     @Test
-    void getLong_keyOnly_configurationWithoutNamespace()
+    void getLong_keyOnlyAndLenient_configurationWithoutNamespace()
     {
         container = new ConfigurationContainer(CONF_NS1_PROPERTIES_1, CONF_NS2_PROPERTIES_1, CONF_PROPERTIES_1);
+        assertThat(container.getLong(KEY_LONG), equalTo(111L)); // CONF_NS1_PROPERTIES_1
+    }
+
+    @Test
+    void getLong_keyOnlyAndStrict_configurationWithoutNamespace()
+    {
+        container = new ConfigurationContainer(DataFetchStrategy.STRICT, CONF_NS1_PROPERTIES_1, CONF_NS2_PROPERTIES_1, CONF_PROPERTIES_1);
         assertThat(container.getLong(KEY_LONG), equalTo(1010L)); // CONF_PROPERTIES1
     }
 

--- a/confectory-core/src/test/java/net/obvj/confectory/TypeSafeConfigurationContainerTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/TypeSafeConfigurationContainerTest.java
@@ -60,27 +60,58 @@ class TypeSafeConfigurationContainerTest
     {
         container = new TypeSafeConfigurationContainer<>();
         assertThat(container.size(), equalTo(0L));
-        assertThat(container.getInternal().getDataFetchStrategy(), equalTo(DataFetchStrategy.STRICT));
+        assertThat(container.getInternal().getDataFetchStrategy(),
+                equalTo(Confectory.settings().getDefaultDataFetchStrategy()));
     }
 
     @Test
-    void getBean_noArgumentAndOnlyConfigsWithNamespace_null()
+    void constructor_dataFetchStrategy_customStrategy()
+    {
+        container = new TypeSafeConfigurationContainer<>(DataFetchStrategy.STRICT_UNSORTED);
+        assertThat(container.size(), equalTo(0L));
+        assertThat(container.getInternal().getDataFetchStrategy(),
+                equalTo(DataFetchStrategy.STRICT_UNSORTED));
+    }
+
+    @Test
+    void getBean_lenientAndNoArgumentAndOnlyConfigsWithNamespace_highestPrecedence()
     {
         container = new TypeSafeConfigurationContainer<>(CONF_NS1_BEAN_1, CONF_NS2_BEAN_1);
+        assertThat(container.getBean(), equalTo(BEAN_1_1));
+    }
+
+    @Test
+    void getBean_strictAndNoArgumentAndOnlyConfigsWithNamespace_null()
+    {
+        container = new TypeSafeConfigurationContainer<>(DataFetchStrategy.STRICT, CONF_NS1_BEAN_1, CONF_NS2_BEAN_1);
         assertThat(container.getBean(), equalTo(null));
     }
 
     @Test
-    void getBean_noArgument_configWithoutNamespace()
+    void getBean_lenientAndNoArgument_highestPrecedence()
     {
         container = new TypeSafeConfigurationContainer<>(CONF_NS1_BEAN_1, CONF_NS2_BEAN_1, CONF_BEAN_3);
+        assertThat(container.getBean(), equalTo(BEAN_1_1));
+    }
+
+    @Test
+    void getBean_strictAndNoArgument_configWithoutNamespace()
+    {
+        container = new TypeSafeConfigurationContainer<>(DataFetchStrategy.STRICT, CONF_NS1_BEAN_1, CONF_NS2_BEAN_1, CONF_BEAN_3);
         assertThat(container.getBean(), equalTo(BEAN_3));
     }
 
     @Test
-    void getBean_invalidNamespace_null()
+    void getBean_lenientAndInvalidNamespace_highestPrecedence()
     {
         container = new TypeSafeConfigurationContainer<>(CONF_NS1_BEAN_1, CONF_NS2_BEAN_1, CONF_BEAN_3);
+        assertThat(container.getBean("invalid"), equalTo(null));
+    }
+
+    @Test
+    void getBean_strictAndinvalidNamespace_null()
+    {
+        container = new TypeSafeConfigurationContainer<>(DataFetchStrategy.STRICT, CONF_NS1_BEAN_1, CONF_NS2_BEAN_1, CONF_BEAN_3);
         assertThat(container.getBean("invalid"), equalTo(null));
     }
 

--- a/confectory-core/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveTypeSafeContainer.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveTypeSafeContainer.java
@@ -17,7 +17,6 @@
 package net.obvj.confectory.testdrive;
 
 import net.obvj.confectory.Configuration;
-import net.obvj.confectory.DataFetchStrategy;
 import net.obvj.confectory.TypeSafeConfigurationContainer;
 import net.obvj.confectory.mapper.PropertiesToObjectMapper;
 import net.obvj.confectory.testdrive.model.MyProperties;

--- a/confectory-core/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveTypeSafeContainer.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveTypeSafeContainer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.obvj.confectory.testdrive;
+
+import net.obvj.confectory.Configuration;
+import net.obvj.confectory.DataFetchStrategy;
+import net.obvj.confectory.TypeSafeConfigurationContainer;
+import net.obvj.confectory.mapper.PropertiesToObjectMapper;
+import net.obvj.confectory.testdrive.model.MyProperties;
+
+public class ConfectoryTestDriveTypeSafeContainer
+{
+    public static void main(String[] args)
+    {
+        Configuration<MyProperties> config1 = Configuration.<MyProperties>builder()
+                .source("classpath://testfiles/my-props.properties")
+                .mapper(new PropertiesToObjectMapper<>(MyProperties.class))
+                .namespace("my-props1")
+                .precedence(100)
+                .build();
+
+        Configuration<MyProperties> config2 = Configuration.<MyProperties>builder()
+                .source("classpath://testfiles/my-props2.properties")
+                .mapper(new PropertiesToObjectMapper<>(MyProperties.class))
+                .namespace("my-props2")
+                .precedence(50)
+                .build();
+
+        Configuration<MyProperties> config3 = Configuration.<MyProperties>builder()
+                .source("classpath://testfiles/notfound.properties") // Non-existent
+                .mapper(new PropertiesToObjectMapper<>(MyProperties.class))
+                .namespace("not-found")
+                .precedence(300)
+                .optional()
+                .build();
+
+        TypeSafeConfigurationContainer<MyProperties> container = new TypeSafeConfigurationContainer<>(
+                config1, config2, config3);
+
+
+        System.out.println();
+        System.out.println("config1            ==> " + config1.getBean());
+        System.out.println("config2            ==> " + config2.getBean());
+        System.out.println("config3            ==> " + config3.getBean());
+        System.out.println("getBean()          ==> " + container.getBean());
+        System.out.println("getBean(my-props1) ==> " + container.getBean("my-props1"));
+        System.out.println("getBean(my-props2) ==> " + container.getBean("my-props2"));
+        System.out.println("getBean(my-props2) ==> " + container.getBean("my-props3"));
+
+    }
+}

--- a/confectory-core/src/test/resources/testfiles/my-props2.properties
+++ b/confectory-core/src/test/resources/testfiles/my-props2.properties
@@ -1,0 +1,6 @@
+web.enable=true
+web.host=localhost
+web.port=1911
+web.path=os2
+web.price=1.09
+myString=best2

--- a/confectory-core/src/test/resources/tinylog.properties
+++ b/confectory-core/src/test/resources/tinylog.properties
@@ -1,0 +1,2 @@
+writer        = console
+writer.format = [{level}]\t{class}.{line}: {message}

--- a/confectory-datamapper-gson/src/test/resources/tinylog.properties
+++ b/confectory-datamapper-gson/src/test/resources/tinylog.properties
@@ -1,0 +1,2 @@
+writer        = console
+writer.format = [{level}]\t{class}.{line}: {message}

--- a/confectory-datamapper-jackson2-json/src/test/resources/tinylog.properties
+++ b/confectory-datamapper-jackson2-json/src/test/resources/tinylog.properties
@@ -1,0 +1,2 @@
+writer        = console
+writer.format = [{level}]\t{class}.{line}: {message}

--- a/confectory-datamapper-jackson2-toml/src/test/resources/tinylog.properties
+++ b/confectory-datamapper-jackson2-toml/src/test/resources/tinylog.properties
@@ -1,0 +1,2 @@
+writer        = console
+writer.format = [{level}]\t{class}.{line}: {message}

--- a/confectory-datamapper-jackson2-xml/src/test/resources/tinylog.properties
+++ b/confectory-datamapper-jackson2-xml/src/test/resources/tinylog.properties
@@ -1,0 +1,2 @@
+writer        = console
+writer.format = [{level}]\t{class}.{line}: {message}

--- a/confectory-datamapper-jackson2-yaml/src/test/resources/tinylog.properties
+++ b/confectory-datamapper-jackson2-yaml/src/test/resources/tinylog.properties
@@ -1,0 +1,2 @@
+writer        = console
+writer.format = [{level}]\t{class}.{line}: {message}

--- a/confectory-datamapper-json-org/src/test/resources/tinylog.properties
+++ b/confectory-datamapper-json-org/src/test/resources/tinylog.properties
@@ -1,0 +1,2 @@
+writer        = console
+writer.format = [{level}]\t{class}.{line}: {message}

--- a/confectory-datamapper-snakeyaml/src/test/resources/tinylog.properties
+++ b/confectory-datamapper-snakeyaml/src/test/resources/tinylog.properties
@@ -1,0 +1,2 @@
+writer        = console
+writer.format = [{level}]\t{class}.{line}: {message}

--- a/pom.xml
+++ b/pom.xml
@@ -52,13 +52,13 @@
 
         <!-- Compile dependencies -->
         <jackson2.version>2.14.1</jackson2.version>
-        <slf4j.version>2.0.6</slf4j.version>
+        <slf4j.version>2.0.5</slf4j.version>
         
         <!-- Test dependencies -->
         <junit.version>5.9.1</junit.version>
         <junit-utils.version>1.3.1</junit-utils.version>
         <mockito.version>4.8.1</mockito.version>
-        <logback.version>1.4.5</logback.version>
+        <tinylog.version>2.5.0</tinylog.version>
         
     </properties>
 
@@ -112,12 +112,18 @@
         </dependency>
 
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-impl</artifactId>
+            <version>${tinylog.version}</version>
             <scope>test</scope>
         </dependency>
-        
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>slf4j-tinylog</artifactId>
+            <version>${tinylog.version}</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
         <!-- Compile dependencies -->
         <jackson2.version>2.14.1</jackson2.version>
-        <slf4j.version>2.0.5</slf4j.version>
+        <slf4j.version>2.0.6</slf4j.version>
         
         <!-- Test dependencies -->
         <junit.version>5.9.1</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,13 +52,13 @@
 
         <!-- Compile dependencies -->
         <jackson2.version>2.14.1</jackson2.version>
-        <slf4j.version>1.7.36</slf4j.version>
+        <slf4j.version>2.0.6</slf4j.version>
         
         <!-- Test dependencies -->
         <junit.version>5.9.1</junit.version>
         <junit-utils.version>1.3.1</junit-utils.version>
         <mockito.version>4.8.1</mockito.version>
-        <logback.version>1.4.4</logback.version>
+        <logback.version>1.4.5</logback.version>
         
     </properties>
 
@@ -117,6 +117,7 @@
             <version>${logback.version}</version>
             <scope>test</scope>
         </dependency>
+        
 
     </dependencies>
 


### PR DESCRIPTION
## Issue

- The `TypeSafeConfigurationContainer` does not allow overwriting the default `DataFetchStrategy` (which is hardcoded as **STRICT**, but not very well aligned with the usability and purpose of this type of container. 

## Proposal

- The default `DataFetchStrategy` form `Confectory.settings()` should be considered by the `TypeSafeConfigurationContainer`
- Optionally, the user should be able to define a different strategy on `TypeSafeConfigurationContainer` construction
- The **LENIENT** `DataFetchStrategy` is better aligned with the purpose of all types of containers, so it should be the initial default strategy



