### PR TITLE
Upgrade com.google.code.gson:gson from 2.10 to 2.10.1

### DIFF
--- a/confectory-datamapper-gson/pom.xml
+++ b/confectory-datamapper-gson/pom.xml
@@ -30,7 +30,7 @@
     </description>
 
     <properties>
-        <gson.version>2.10</gson.version>
+        <gson.version>2.10.1</gson.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
ℹ️ Keep your dependencies up-to-date. This makes it easier to fix existing vulnerabilities and to more quickly identify and fix newly disclosed vulnerabilities when they affect your project.

The recommended version is 1 version ahead of your current version. The recommended version was released 22 days ago, on 2023-01-06.