### PR TITLE
Security upgrade net.minidev:json-smart from 2.4.7 to 2.4.10

### DIFF
--- a/confectory-core/pom.xml
+++ b/confectory-core/pom.xml
@@ -35,6 +35,7 @@
         <commons-text.version>1.10.0</commons-text.version>
         <jsonmerge.version>1.2.0</jsonmerge.version>
         <json-path.version>2.7.0</json-path.version>
+        <json-smart.version>2.4.10</json-smart.version>
         <performetrics.version>2.3.0</performetrics.version>
     </properties>
 
@@ -62,6 +63,12 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <version>${json-path.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>${json-smart.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### Impact
Affected versions of [net.minidev:json-smart](https://github.com/netplex/json-smart-v1) are vulnerable to Denial of Service (DoS) due to a StackOverflowError when parsing a deeply nested JSON array or object.

When reaching a ‘[‘ or ‘{‘ character in the JSON input, the code parses an array or an object respectively. It was discovered that the 3PP does not have any limit to the nesting of such arrays or objects. Since the parsing of nested arrays and objects is done recursively, nesting too many of them can cause stack exhaustion (stack overflow) and crash the software.

### Patches
This vulnerability was fixed in json-smart version 2.4.9, but the maintainer recommends upgrading to 2.4.10, due to a remaining bug.

### Workarounds
N/A

### References
- https://www.cve.org/CVERecord?id=CVE-2023-1370
- https://nvd.nist.gov/vuln/detail/CVE-2023-1370
- https://security.snyk.io/vuln/SNYK-JAVA-NETMINIDEV-3369748