### PR TITLE
Add support to enum types

### DIFF
--- a/confectory-core/src/test/java/net/obvj/confectory/mapper/PropertiesToObjectMapperTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/mapper/PropertiesToObjectMapperTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.time.DayOfWeek;
 import java.time.format.DateTimeParseException;
 import java.util.Date;
 import java.util.Locale;
@@ -54,7 +55,9 @@ class PropertiesToObjectMapperTest
                     + "intValue=1910\n";
 
     private static final Date DATE_UTC = TestUtils.toDateUtc(2023, 05, 12, 18, 50, 59, 0);
-    private static final String TEST_PROPERTIES_DATE = "myDate=2023-05-12T15:50:59-03:00\n";
+    private static final String TEST_PROPERTIES_DATE = "myDate=2023-05-12T15:50:59-03:00\n"
+                                                     + "dayOfWeek=friday\n";
+
     private static final String TEST_PROPERTIES_INVALID_DATE = "myDate=2023a05-12T15:50:59-03:00\n";
 
 
@@ -113,6 +116,7 @@ class PropertiesToObjectMapperTest
     static class MyBeanDate
     {
         Date myDate;
+        DayOfWeek dayOfWeek;
 
         public MyBeanDate() {}
     }
@@ -195,6 +199,7 @@ class PropertiesToObjectMapperTest
                 .apply(newInputStream(TEST_PROPERTIES_DATE));
 
         assertThat(bean.myDate, equalTo(DATE_UTC));
+        assertThat(bean.dayOfWeek, equalTo(DayOfWeek.FRIDAY));
     }
 
     @Test

--- a/confectory-core/src/test/java/net/obvj/confectory/util/ParseFactoryTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/util/ParseFactoryTest.java
@@ -180,15 +180,18 @@ class ParseFactoryTest
     }
 
     @Test
-    void parse_month_success()
+    void parse_enumTypesCaseInsensitive_success()
     {
         assertThat(ParseFactory.parse(Month.class, "JULY"), equalTo(Month.JULY));
+        assertThat(ParseFactory.parse(Month.class, "aUguSt"), equalTo(Month.AUGUST));
+        assertThat(ParseFactory.parse(DayOfWeek.class, "FRIDAY"), equalTo(DayOfWeek.FRIDAY));
+        assertThat(ParseFactory.parse(DayOfWeek.class, "saturday"), equalTo(DayOfWeek.SATURDAY));
     }
 
     @Test
-    void parse_dayOfWeek_success()
+    void parse_invalidEnumElement_null()
     {
-        assertThat(ParseFactory.parse(DayOfWeek.class, "FRIDAY"), equalTo(DayOfWeek.FRIDAY));
+        assertThat(ParseFactory.parse(Month.class, "unknown"), equalTo(null));
     }
 
 }


### PR DESCRIPTION
The `ParseFactory` may perform parsing of <b>Enum</b> elements which can be retrieved based on their constant names, performing case-insensitive matching of the name.

For example:
````java
ParseFactory.parse(Month.class, "january");    // returns Month.JANUARY
ParseFactory.parse(DayOfWeek.class, "friday"); // returns DayOfWeek.FRIDAY
````

So the mappers `PropertiesToObjectMapper<T>` and `INIToObjectMapper<T>` may benefit from it by populating enum fields.