### PR TITLE
Infer the mapper based on the file extension

### DIFF
--- a/confectory-core/src/main/java/net/obvj/confectory/mapper/DynamicMapper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/mapper/DynamicMapper.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.obvj.confectory.mapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.obvj.confectory.internal.helper.ConfigurationHelper;
+import net.obvj.confectory.util.Exceptions;
+
+/**
+ * A dynamic {@link Mapper} which automatically assigns a concrete mapping class
+ * (from the default core mappers) depending on a given file extension:
+ * <ul>
+ * <li><code>"ini"</code> assigns the {@link INIToJSONObjectMapper}
+ * <li><code>"json"</code> assigns the {@link JSONObjectMapper}
+ * <li><code>"properties"</code> assigns the {@link PropertiesMapper}
+ * <li><code>"txt"</code> assigns the {@link StringMapper}
+ * <li><code>"xml"</code> assigns the {@link DocumentMapper}
+ * </ul>
+ *
+ * @author oswaldo.bapvic.jr (Oswaldo Junior)
+ * @since 2.6.0
+ */
+public final class DynamicMapper extends AbstractBeanMapper<Object> implements Mapper<Object>
+{
+    private static final Map<String, Supplier<Mapper<?>>> MAPPERS_BY_EXTENSION = Map.of(
+            "ini", INIToJSONObjectMapper::new,
+            "json", JSONObjectMapper::new,
+            "properties", PropertiesMapper::new,
+            "txt", StringMapper::new,
+            "xml", DocumentMapper::new
+    );
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DynamicMapper.class);
+
+    private final Mapper<Object> actualMapper;
+
+    /**
+     * Builds a new dynamic configuration mapper for the specified extension
+     *
+     * @param extension the file extension; not null
+     * @throws IllegalArgumentException if the extension is empty or unknown
+     */
+    public DynamicMapper(String extension)
+    {
+        this.actualMapper = findMapper(extension);
+    }
+
+    private static Mapper<Object> findMapper(String extension)
+    {
+        Supplier<Mapper<?>> supplier = MAPPERS_BY_EXTENSION.get(StringUtils.lowerCase(extension));
+        if (supplier == null)
+        {
+            throw Exceptions.illegalArgument(
+                    "No default mapper available for the extension: \"%s\"", extension);
+        }
+        return (Mapper<Object>) supplier.get();
+    }
+
+    @Override
+    public Object apply(InputStream inputStream) throws IOException
+    {
+        LOGGER.debug("Applying mapper {}", actualMapper.getClass());
+        return actualMapper.apply(inputStream);
+    }
+
+    @Override
+    public ConfigurationHelper<Object> configurationHelper(Object bean)
+    {
+        return actualMapper.configurationHelper(bean);
+    }
+
+    /**
+     * @return The actual mapper
+     */
+    public Mapper<Object> getActualMapper()
+    {
+        return actualMapper;
+    }
+
+}

--- a/confectory-core/src/test/java/net/obvj/confectory/mapper/DynamicMapperTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/mapper/DynamicMapperTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.obvj.confectory.mapper;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import net.obvj.junit.utils.matchers.AdvancedMatchers;
+
+/**
+ * Unit tests for the {@link DynamicMapper}.
+ *
+ * @author oswaldo.bapvic.jr
+ * @since 2.6.0
+ */
+class DynamicMapperTest
+{
+    static final String TEST_INI_CONTENT = "[web]\nhost=localhost\nport=1910";
+    static final String TEST_PROPERTIES_CONTENT = "web.host=localhost\nweb.port=1910";
+    static final String TEST_JSON_CONTENT = "{\"web\":{\"host\":\"localhost\",\"port\":1910}}";
+    static final String TEST_TXT_CONTENT = "localhost:1910";
+    static final String TEST_XML_CONTENT = "<web><host>localhost</host><port>1910</port></web>";
+
+    private static ByteArrayInputStream asInputStream(String string)
+    {
+        return new ByteArrayInputStream(string.getBytes());
+    }
+
+    @Test
+    void apply_ini_loadedSuccessfully() throws IOException
+    {
+        Mapper<Object> mapper = new DynamicMapper("INI");
+        Object bean = mapper.apply(asInputStream(TEST_INI_CONTENT));
+        assertThat(mapper.configurationHelper(bean).getString("web.host"), equalTo("localhost"));
+    }
+
+    @Test
+    void apply_json_loadedSuccessfully() throws IOException
+    {
+        Mapper<Object> mapper = new DynamicMapper("JSON");
+        Object bean = mapper.apply(asInputStream(TEST_JSON_CONTENT));
+        assertThat(mapper.configurationHelper(bean).getString("$.web.host"), equalTo("localhost"));
+    }
+
+    @Test
+    void apply_properties_loadedSuccessfully() throws IOException
+    {
+        Mapper<Object> mapper = new DynamicMapper("PROPERTIES");
+        Object bean = mapper.apply(asInputStream(TEST_PROPERTIES_CONTENT));
+        assertThat(mapper.configurationHelper(bean).getInteger("web.port"), equalTo(1910));
+    }
+
+    @Test
+    void apply_txt_loadedSuccessfully() throws IOException
+    {
+        Mapper<Object> mapper = new DynamicMapper("TXT");
+        Object bean = mapper.apply(asInputStream(TEST_TXT_CONTENT));
+        assertThat(mapper.configurationHelper(bean).getAsString(), equalTo("localhost:1910"));
+    }
+
+    @Test
+    void apply_xml_loadedSuccessfully() throws IOException
+    {
+        Mapper<Object> mapper = new DynamicMapper("XML");
+        Object bean = mapper.apply(asInputStream(TEST_XML_CONTENT));
+        assertThat(mapper.configurationHelper(bean).getInteger("/web/port"), equalTo(1910));
+    }
+
+    @Test
+    void constructor_unknown_illegalArgument()
+    {
+        assertThat(() -> new DynamicMapper("unknown"),
+                AdvancedMatchers.throwsException(IllegalArgumentException.class)
+                        .withMessage("No default mapper available for the extension: \"unknown\""));
+    }
+
+}

--- a/confectory-core/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveGenericMapperIni.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveGenericMapperIni.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.obvj.confectory.testdrive;
+
+import net.obvj.confectory.Configuration;
+
+public class ConfectoryTestDriveGenericMapperIni
+{
+    public static void main(String[] args)
+    {
+        Configuration<?> config = Configuration.builder()
+                .source("testfiles/my-app.ini")
+                .lazy()
+                .build();
+
+        System.out.println(config.getBean());
+        System.out.println();
+        System.out.println(config.getAsString());
+        System.out.println();
+        System.out.println(config.getString("title"));
+        System.out.println(config.getString("owner.organization"));
+        System.out.println(config.getInteger("database.port"));
+
+    }
+}

--- a/confectory-core/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveGenericMapperProperties.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveGenericMapperProperties.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.obvj.confectory.testdrive;
+
+import net.obvj.confectory.Configuration;
+
+public class ConfectoryTestDriveGenericMapperProperties
+{
+    public static void main(String[] args)
+    {
+        Configuration<?> config = Configuration.builder()
+                .source("testfiles/my-props.properties")
+                .required()
+                .build();
+
+        System.out.println(config.getBean());
+        System.out.println();
+        System.out.println(config.getAsString());
+        System.out.println();
+        System.out.println(config.getString("web.host"));
+        System.out.println(config.getInteger("web.port"));
+
+    }
+}

--- a/confectory-core/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveGenericMapperXml.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveGenericMapperXml.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.obvj.confectory.testdrive;
+
+import net.obvj.confectory.Configuration;
+
+public class ConfectoryTestDriveGenericMapperXml
+{
+    public static void main(String[] args)
+    {
+        Configuration<?> config = Configuration.builder()
+                .source("testfiles/note.xml")
+                .build();
+
+        System.out.println(config.getBean());
+        System.out.println();
+        System.out.println(config.getAsString());
+        System.out.println();
+        System.out.println(config.getString("note/to"));
+        System.out.println(config.getString("note/from"));
+        System.out.println(config.getString("note/heading"));
+        System.out.println(config.getString("note/body"));
+
+    }
+}

--- a/confectory-core/src/test/resources/testfiles/note.xml
+++ b/confectory-core/src/test/resources/testfiles/note.xml
@@ -1,0 +1,6 @@
+<note>
+  <to>Tove</to>
+  <from>Jani</from>
+  <heading>Reminder</heading>
+  <body>Go, Corinthians!</body>
+</note>


### PR DESCRIPTION
## Enhancement

This enhancement adds the possibility to omit the mapper from the `ConfigurationBuilder` and let a default mapper (from the core mappers) be inferred based on the file extension, if present.

This will allow for a more simplified setup, like the following example:

#### Example 1 - Let the `DocumentMapper` be automatically assigned for the XML file

````java
        // Generic configuration
        Configuration<?> config = Configuration.builder()
                .source("testfiles/note.xml") .build();

        // Use XPaths
        System.out.println(config.getString("note/to"));
        System.out.println(config.getString("note/from"));
        System.out.println(config.getString("note/heading"));
        System.out.println(config.getString("note/body"));
```` 


#### Example 2 - Let the `JSONObjectMapper` be automatically assigned for the JSON file

````java
        // Generic configuration
        Configuration<?> config = Configuration.builder()
                .source("testfiles/note.json") .build();

        // Use JSONPaths
        System.out.println(config.getString("$.note.to"));
        System.out.println(config.getString("$.note.from"));
        System.out.println(config.getString("$.note.heading"));
        System.out.println(config.getString("$.note.body"));
```` 