### PR TITLE
Support XPath expressions that do not return a node set

### DIFF
--- a/confectory-core/src/main/java/net/obvj/confectory/ConfigurationDataRetriever.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/ConfigurationDataRetriever.java
@@ -53,6 +53,8 @@ public interface ConfigurationDataRetriever<T>
      * <ul>
      * <li>The actual return type may vary depending on the underlying implementation</li>
      * <li>On a JSON implementation, the return will usually be an array</li>
+     * <li>On an XML implementation, the return will vary depending on the result type of the
+     * {@code XPath} expression: nodes, number, string, or boolean</li>
      * </ul>
      *
      * @param key the object key (some implementations may also accept a path expression, e.g:

--- a/confectory-core/src/main/java/net/obvj/confectory/internal/helper/DocumentConfigurationHelper.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/internal/helper/DocumentConfigurationHelper.java
@@ -18,14 +18,14 @@ package net.obvj.confectory.internal.helper;
 
 import java.util.Objects;
 
-import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathEvaluationResult;
+import javax.xml.xpath.XPathEvaluationResult.XPathResultType;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.XPathNodes;
 
 import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 import net.obvj.confectory.ConfigurationException;
 import net.obvj.confectory.merger.ConfigurationMerger;
@@ -48,7 +48,7 @@ public class DocumentConfigurationHelper extends AbstractConfigurationHelper<Doc
     /**
      * Creates a new helper for the given XML {@link Document}.
      *
-     * @param document the JSON document to set
+     * @param document the XML document to set
      */
     public DocumentConfigurationHelper(Document document)
     {
@@ -82,6 +82,12 @@ public class DocumentConfigurationHelper extends AbstractConfigurationHelper<Doc
      * If no value is found for the given expression and the {@code mandatory} flag is
      * {@code true}, an exception will be thrown; if the flag is not set, then the method
      * returns {@code null}.
+     * <p>
+     * <strong>Note:</strong> An expression that does not return a node set, such as
+     * {@code number(...)}, {@code count(...)}, {@code string(...)} or {@code boolean(...)},
+     * always produces a single value, so the {@code mandatory} flag has no effect on it. For
+     * example, {@code count(/unknown)} evaluates to zero and {@code boolean(/unknown)}
+     * evaluates to {@code false}.
      *
      * @param xpath      the {@code XPath} expression to evaluate
      * @param targetType the type the evaluation result should be converted to
@@ -100,8 +106,15 @@ public class DocumentConfigurationHelper extends AbstractConfigurationHelper<Doc
     @Override
     protected <T> T getValue(String xpath, Class<T> targetType, boolean mandatory)
     {
-        NodeList result = get(xpath).getNodeList();
-        switch (result.getLength())
+        XPathEvaluationResult<?> result = evaluate(xpath, XPathEvaluationResult.class);
+        if (result.type() != XPathResultType.NODESET)
+        {
+            // Expressions such as number(...) or count(...) produce a single, atomic value:
+            // let the engine apply the XPath string conversion rules on it
+            return parse(xpath, targetType, evaluate(xpath, String.class));
+        }
+        XPathNodes nodes = (XPathNodes) result.value();
+        switch (nodes.size())
         {
         case 0:
             if (mandatory)
@@ -110,45 +123,35 @@ public class DocumentConfigurationHelper extends AbstractConfigurationHelper<Doc
             }
             return null;
         case 1:
-            try
-            {
-                Node node = result.item(0);
-                return TypeFactory.parse(targetType, node.getTextContent());
-            }
-            catch (ParseException parseException)
-            {
-                throw new ConfigurationException(parseException,
-                        "The path %s was found but the object can not be converted into %s",
-                        xpath, targetType);
-            }
+            return parse(xpath, targetType, nodes.iterator().next().getTextContent());
         default:
             throw new ConfigurationException("Multiple values found for path: %s", xpath);
         }
     }
 
     /**
-     * Returns the {@link NodeList} object associated with the specified @{code XPath} in the
-     * XML document in context.
+     * Returns the object associated with the specified {@code XPath} expression in the XML
+     * document in context.
+     * <p>
+     * <b>Note:</b> The actual return type may vary depending on the expression: one that
+     * selects nodes produces an object holding those nodes, whereas the expressions
+     * {@code number(...)}, {@code string(...)} and {@code boolean(...)} produce a
+     * {@link Double}, a {@link String}, and a {@link Boolean}, respectively.
      *
      * @param xpath the {@code XPath} expression to read
      *
-     * @return the {@link NodeList} object associated with the specified {@code XPath}
+     * @return the object associated with the specified {@code XPath}
      *
      * @throws NullPointerException   if the {@code XPath} expression is null
      * @throws ConfigurationException if the {@code XPath} expression is not valid
      */
     @Override
-    public NodeListHolder get(String xpath)
+    public Object get(String xpath)
     {
-        try
-        {
-            NodeList nodeList = (NodeList) compileXPath(xpath).evaluate(document, XPathConstants.NODESET);
-            return new NodeListHolder(nodeList);
-        }
-        catch (XPathExpressionException exception)
-        {
-            throw new ConfigurationException(exception);
-        }
+        XPathEvaluationResult<?> result = evaluate(xpath, XPathEvaluationResult.class);
+        return result.type() == XPathResultType.NODESET
+                ? new NodeListHolder((XPathNodes) result.value())
+                : result.value();
     }
 
     /**
@@ -170,31 +173,73 @@ public class DocumentConfigurationHelper extends AbstractConfigurationHelper<Doc
     }
 
     /**
-     * This holds a {@link NodeList} and provides a better way to display it as string.
+     * Evaluates the specified {@code XPath} expression on the XML document in context.
+     *
+     * @param xpath      the {@code XPath} expression to evaluate
+     * @param resultType one of the types accepted by
+     *                   {@link XPathExpression#evaluateExpression(Object, Class)}; in
+     *                   particular, {@code XPathEvaluationResult.class} preserves the result
+     *                   type defined by the expression itself
+     *
+     * @return the evaluation result, converted to the specified {@code resultType}
+     * @throws ConfigurationException if the {@code XPath} expression is not valid
+     */
+    private <T> T evaluate(String xpath, Class<T> resultType)
+    {
+        try
+        {
+            return compileXPath(xpath).evaluateExpression(document, resultType);
+        }
+        catch (XPathExpressionException exception)
+        {
+            throw new ConfigurationException(exception);
+        }
+    }
+
+    /**
+     * Converts the specified value into the specified type.
+     *
+     * @param xpath      the {@code XPath} expression that produced the value, for reporting
+     *                   purposes
+     * @param targetType the type the value should be converted to
+     * @param value      the value to be converted
+     *
+     * @return the value converted into the specified {@code targetType}
+     * @throws ConfigurationException if the value can not be converted
+     */
+    private <T> T parse(String xpath, Class<T> targetType, String value)
+    {
+        try
+        {
+            return TypeFactory.parse(targetType, value);
+        }
+        catch (ParseException parseException)
+        {
+            throw new ConfigurationException(parseException,
+                    "The path %s was found but the object can not be converted into %s",
+                    xpath, targetType);
+        }
+    }
+
+    /**
+     * This holds the nodes selected by an {@code XPath} expression and provides a better way
+     * to display them as string.
      *
      * @since 2.5.0
      */
     static class NodeListHolder
     {
-        private final NodeList nodeList;
+        private final XPathNodes nodes;
 
-        NodeListHolder(final NodeList nodeList)
+        NodeListHolder(final XPathNodes nodes)
         {
-            this.nodeList = Objects.requireNonNull(nodeList, "The node list is null");
-        }
-
-        /**
-         * @return the XML node list
-         */
-        public NodeList getNodeList()
-        {
-            return nodeList;
+            this.nodes = Objects.requireNonNull(nodes, "The node list is null");
         }
 
         @Override
         public String toString()
         {
-            return XMLUtils.toString(nodeList);
+            return XMLUtils.toString(nodes);
         }
 
     }

--- a/confectory-core/src/main/java/net/obvj/confectory/util/XMLUtils.java
+++ b/confectory-core/src/main/java/net/obvj/confectory/util/XMLUtils.java
@@ -19,6 +19,7 @@ package net.obvj.confectory.util;
 import java.io.StringWriter;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -95,6 +96,21 @@ public class XMLUtils
     {
         return IntStream.range(0, nodeList.getLength())
                 .mapToObj(nodeList::item)
+                .map(XMLUtils::toString)
+                .collect(Collectors.joining("\n"));
+    }
+
+    /**
+     * Returns a string representation of the specified XML nodes.
+     *
+     * @param nodes the nodes to be converted
+     * @return the nodes as string
+     * @throws ConfigurationException if unable to convert a document node into string
+     * @since 2.6.1
+     */
+    public static String toString(Iterable<Node> nodes)
+    {
+        return StreamSupport.stream(nodes.spliterator(), false)
                 .map(XMLUtils::toString)
                 .collect(Collectors.joining("\n"));
     }

--- a/confectory-core/src/test/java/net/obvj/confectory/internal/helper/DocumentConfigurationHelperTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/internal/helper/DocumentConfigurationHelperTest.java
@@ -318,6 +318,65 @@ class DocumentConfigurationHelperTest
     }
 
     @Test
+    void getInteger_numberFunction_success()
+    {
+        assertThat(HELPER.getInteger("number(/bookstore/book[1]/year)"), equalTo(2005));
+    }
+
+    @Test
+    void getInteger_countFunction_success()
+    {
+        assertThat(HELPER.getInteger("count(/bookstore/book)"), equalTo(4));
+    }
+
+    @Test
+    void getMandatoryInteger_countFunctionPathNotFound_zero()
+    {
+        assertThat(HELPER.getMandatoryInteger("count(" + PATH_UNKNOWN + ")"), equalTo(0));
+    }
+
+    @Test
+    void getInteger_notANumberFunction_exception()
+    {
+        assertThat(() -> HELPER.getInteger("number(/bookstore/book[1]/title)"),
+                throwsException(ConfigurationException.class)
+                        .withMessageContaining(
+                                "was found but the object can not be converted into class java.lang.Integer")
+                        .withCause(ParseException.class));
+    }
+
+    @Test
+    void getDouble_numberFunction_success()
+    {
+        assertThat(HELPER.getDouble("number(/bookstore/book[2]/price)"), equalTo(29.99));
+    }
+
+    @Test
+    void getString_stringFunction_success()
+    {
+        assertThat(HELPER.getString("string(/bookstore/book[1]/title)"),
+                equalTo("Everyday Italian"));
+    }
+
+    @Test
+    void getString_stringFunctionPathNotFound_emptyString()
+    {
+        assertThat(HELPER.getString("string(" + PATH_UNKNOWN + ")"), equalTo(""));
+    }
+
+    @Test
+    void getBoolean_booleanFunction_success()
+    {
+        assertThat(HELPER.getBoolean("boolean(/bookstore/book)"), equalTo(true));
+    }
+
+    @Test
+    void getBoolean_booleanFunctionPathNotFound_false()
+    {
+        assertThat(HELPER.getBoolean("boolean(" + PATH_UNKNOWN + ")"), equalTo(false));
+    }
+
+    @Test
     void get_pathPointsToSinlgeElementNode_success()
     {
         String expectedElementAsString = "<book category=\"cooking\">\n"
@@ -365,5 +424,23 @@ class DocumentConfigurationHelperTest
         assertThat(elementsAsStringLines, equalTo(expectedElementsAsStringLines));
     }
 
+    @Test
+    void get_numberFunction_number()
+    {
+        assertThat(HELPER.get("count(/bookstore/book)"), equalTo((Object) 4.0));
+    }
+
+    @Test
+    void get_stringFunction_string()
+    {
+        assertThat(HELPER.get("string(/bookstore/book[1]/title)"),
+                equalTo((Object) "Everyday Italian"));
+    }
+
+    @Test
+    void get_booleanFunction_boolean()
+    {
+        assertThat(HELPER.get("boolean(/bookstore/book)"), equalTo((Object) true));
+    }
 
 }

--- a/confectory-core/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveXmlDocumentXPath.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/testdrive/ConfectoryTestDriveXmlDocumentXPath.java
@@ -58,6 +58,10 @@ public class ConfectoryTestDriveXmlDocumentXPath
         System.out.println(config.getString("//company[last()-1]"));
         System.out.println(config.getString("//company[@id=8]"));
         System.out.println(config.getInteger("//company[1]/@id"));
+        System.out.println(config.getInteger("number(//employee[last()]/@id)"));
+        System.out.println(config.getInteger("count(//employee)"));
+        System.out.println(config.getString("string(//employee[1])"));
+        System.out.println(config.getBoolean("boolean(//employee[@id=1])"));
 
     }
 }

--- a/confectory-core/src/test/java/net/obvj/confectory/util/XMLUtilsTest.java
+++ b/confectory-core/src/test/java/net/obvj/confectory/util/XMLUtilsTest.java
@@ -17,9 +17,17 @@
 package net.obvj.confectory.util;
 
 import static net.obvj.junit.utils.matchers.AdvancedMatchers.instantiationNotAllowed;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.util.Arrays;
+
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import net.obvj.confectory.mapper.DocumentMapper;
+import net.obvj.confectory.source.StringSource;
 
 /**
  * Unit tests for the {@link XMLUtils}.
@@ -29,10 +37,43 @@ import org.junit.jupiter.api.Test;
  */
 class XMLUtilsTest
 {
+    private static final String BOOKS_XML_AS_STR = "<bookstore>"
+            + "<book>Everyday Italian</book>"
+            + "<book>Harry Potter</book>"
+            + "</bookstore>";
+
+    private static final String BOOKS_AS_STR = "<book>Everyday Italian</book>\n"
+            + "<book>Harry Potter</book>";
+
+    private static final Document BOOKS_XML = new StringSource<Document>(BOOKS_XML_AS_STR)
+            .load(new DocumentMapper());
+
+    private static final NodeList BOOKS = BOOKS_XML.getElementsByTagName("book");
+
     @Test
     void constructor_instantiationNotAllowed()
     {
         assertThat(XMLUtils.class,
                 instantiationNotAllowed().throwing(IllegalStateException.class));
+    }
+
+    @Test
+    void toString_nodeList_allNodesAsString()
+    {
+        assertThat(XMLUtils.toString(BOOKS), equalTo(BOOKS_AS_STR));
+    }
+
+    @Test
+    void toString_iterableOfNodes_allNodesAsString()
+    {
+        assertThat(XMLUtils.toString(Arrays.asList(BOOKS.item(0), BOOKS.item(1))),
+                equalTo(BOOKS_AS_STR));
+    }
+
+    @Test
+    void toString_textNode_textContent()
+    {
+        assertThat(XMLUtils.toString(BOOKS.item(0).getFirstChild()),
+                equalTo("Everyday Italian"));
     }
 }

--- a/confectory-datamapper-saxon12/src/test/java/net/obvj/confectory/internal/helper/SaxonXdmNodeConfigurationHelperTest.java
+++ b/confectory-datamapper-saxon12/src/test/java/net/obvj/confectory/internal/helper/SaxonXdmNodeConfigurationHelperTest.java
@@ -317,6 +317,65 @@ class SaxonXdmNodeConfigurationHelperTest
     }
 
     @Test
+    void getInteger_numberFunction_success()
+    {
+        assertThat(HELPER.getInteger("number(/bookstore/book[1]/year)"), equalTo(2005));
+    }
+
+    @Test
+    void getInteger_countFunction_success()
+    {
+        assertThat(HELPER.getInteger("count(/bookstore/book)"), equalTo(4));
+    }
+
+    @Test
+    void getMandatoryInteger_countFunctionPathNotFound_zero()
+    {
+        assertThat(HELPER.getMandatoryInteger("count(" + PATH_UNKNOWN + ")"), equalTo(0));
+    }
+
+    @Test
+    void getInteger_notANumberFunction_exception()
+    {
+        assertThat(() -> HELPER.getInteger("number(/bookstore/book[1]/title)"),
+                throwsException(ConfigurationException.class)
+                        .withMessageContaining(
+                                "was found but the object can not be converted into class java.lang.Integer")
+                        .withCause(ParseException.class));
+    }
+
+    @Test
+    void getDouble_numberFunction_success()
+    {
+        assertThat(HELPER.getDouble("number(/bookstore/book[2]/price)"), equalTo(29.99));
+    }
+
+    @Test
+    void getString_stringFunction_success()
+    {
+        assertThat(HELPER.getString("string(/bookstore/book[1]/title)"),
+                equalTo("Everyday Italian"));
+    }
+
+    @Test
+    void getString_stringFunctionPathNotFound_emptyString()
+    {
+        assertThat(HELPER.getString("string(" + PATH_UNKNOWN + ")"), equalTo(""));
+    }
+
+    @Test
+    void getBoolean_booleanFunction_success()
+    {
+        assertThat(HELPER.getBoolean("boolean(/bookstore/book)"), equalTo(true));
+    }
+
+    @Test
+    void getBoolean_booleanFunctionPathNotFound_false()
+    {
+        assertThat(HELPER.getBoolean("boolean(" + PATH_UNKNOWN + ")"), equalTo(false));
+    }
+
+    @Test
     void get_pathPointsToSinlgeElementNode_success()
     {
         String expectedElementAsString = "<book category=\"cooking\">\n"


### PR DESCRIPTION
Fixes #201

## Problem

Any XPath expression whose result type is not a node set — `number(...)`, `count(...)`, `string(...)`, `boolean(...)`, or arithmetic — fails on a `Configuration<Document>`:

```java
config.getInteger("number(//employee[last()]/@id)");
```

```
net.obvj.confectory.ConfigurationException: javax.xml.xpath.XPathExpressionException:
    com.sun.org.apache.xpath.internal.XPathException: Can not convert #NUMBER to a NodeList!
```

## Root cause

`DocumentConfigurationHelper` hard-coded the result type of every evaluation as a node set:

```java
NodeList nodeList = (NodeList) compileXPath(xpath).evaluate(document, XPathConstants.NODESET);
```

XPath 1.0 defines four result types (node-set, number, string and boolean), so the engine legitimately refuses to coerce a number into a `NodeList`.

## Solution

The document is now evaluated preserving the result type defined by the expression itself, via `XPathExpression.evaluateExpression(Object, Class)` (JAXP 1.6, available on the project's Java 11 baseline). This is the DOM counterpart of what `SaxonXdmNodeConfigurationHelper` already does with its untyped `XdmValue` — so both XML providers now honor the same contract.

- **Node set:** unchanged semantics (empty ⇒ `null` or *"No value found"*, more than one ⇒ *"Multiple values found"*), still resolved in a single evaluation.
- **Atomic result:** converted into string by the XPath engine, so that the XPath string conversion rules apply, and then parsed into the target type by `TypeFactory`. Letting the engine do it is what makes `number(...)` usable as an `Integer`: the raw value is a `Double`, and `Double.toString(5.0)` would yield `"5.0"`, which is not a parsable `int`, whereas the XPath conversion yields `"5"` (and `"1.5"`, `"NaN"` where appropriate).

Since a non-node-set expression always produces exactly one value, the `mandatory` flag has no effect on it: `count(/unknown)` is `0`, `string(/unknown)` is `""` and `boolean(/unknown)` is `false` — never `null`. This is documented in the Javadoc.

## Behavior

| Expression | Before | After |
|---|---|---|
| `config.getInteger("number(//employee[last()]/@id)")` | `ConfigurationException` | `5` |
| `config.getInteger("count(//employee)")` | `ConfigurationException` | `5` |
| `config.getString("string(//employee[1])")` | `ConfigurationException` | `Johnny Dapp` |
| `config.getBoolean("boolean(//employee[@id=1])")` | `ConfigurationException` | `true` |
| `config.get("count(//employee)")` | `ConfigurationException` | `5.0` |
| `config.get("//employee")` | node list | node list (unchanged) |

## Notes for the reviewer

- `DocumentConfigurationHelper.get(String)` now returns `Object` instead of the package-private `NodeListHolder` — the type already declared by `ConfigurationDataRetriever.get(String)`, whose Javadoc states that *"the actual return type may vary depending on the underlying implementation"*. For non-node-set expressions it returns a `Double`, a `String` or a `Boolean`; this is the only visible behavior change beyond the fix itself.
- `XMLUtils.toString(Iterable<Node>)` was added (`@since 2.6.1`) to render the nodes selected by an expression; the existing `toString(NodeList)` overload is untouched.
- An atomic expression is evaluated twice: once preserving its result type, once asking the engine for the string representation. The alternative — formatting the `double` by hand — would mean reimplementing the XPath number-to-string rules (`NaN`, `±Infinity`, negative zero, no exponent), which is easy to get subtly wrong. Node-set expressions, the common case, are still resolved in a single evaluation.

## Tests

- `DocumentConfigurationHelperTest`: 9 new tests covering `number()`, `count()`, `string()` and `boolean()` (including the not-found and `NaN` cases), plus 3 covering the new return types of `get(...)`.
- `SaxonXdmNodeConfigurationHelperTest`: the same 9 getter tests mirrored, pinning the contract shared by the two XML providers (no production change was needed in that module).
- `XMLUtilsTest`: direct tests for both `toString` overloads and for the text-node case.
- `ConfectoryTestDriveXmlDocumentXPath`: the expressions from the issue added to the manual test drive.

`mvn test` passes on the whole reactor.
